### PR TITLE
fix(m01/ex01): fix typo and callout formatting in exercise introduction

### DIFF
--- a/Instructions/Labs/M01-empower-workforce-copilot-executives/02-Ex1-introduction-synthesize-exercise.md
+++ b/Instructions/Labs/M01-empower-workforce-copilot-executives/02-Ex1-introduction-synthesize-exercise.md
@@ -1,6 +1,6 @@
 ---
 lab:
-  title: 'Exercise 1: Synthesize communication insights across Microsoft Team'
+  title: 'Exercise 1: Synthesize communication insights across Microsoft Teams'
   description: For executives, their time is their most valuable asset. They’re responsible for steering critical initiatives, making informed decisions, and maintaining visibility across multiple workstreams. As part of this exercise, you use both Copilot features in Microsoft Teams to quickly synthesize the emails, meetings, and chats related to a key project that you’re currently working on—just as an executive would when preparing for a board update or strategic review.
   duration: 12 minutes
   level: 200
@@ -9,7 +9,7 @@ lab:
     - Microsoft Teams
 ---
 
-# Exercise 1: Synthesize communication insights across Microsoft Team
+# Exercise 1: Synthesize communication insights across Microsoft Teams
 ---
 In today's dynamic business landscape, effective communication is key to staying ahead. As executives navigate the vast ocean of information, Microsoft Teams emerges as a powerful tool they can use to streamline their communication experience. Within Teams, Copilot empowers you with a quick and efficient overview of key discussions, ensuring that you stay informed without being overwhelmed.
 
@@ -22,7 +22,5 @@ When you think of Microsoft Teams, you typically think of Teams' chat. However, 
 ### Scenario
 For executives, their time is their most valuable asset. They’re responsible for steering critical initiatives, making informed decisions, and maintaining visibility across multiple workstreams. As part of this exercise, you use both Copilot features in Microsoft Teams to quickly synthesize the emails, meetings, and chats related to a key project that you’re currently working on—just as an executive would when preparing for a board update or strategic review.
 
->[!NOTE]
+> [!NOTE]
 > This course doesn’t include a Microsoft 365 lab tenant with fictitious data. Instead, you must complete this training exercise using your own personal data.
-
-


### PR DESCRIPTION
## Summary
Fixes a typo in the Exercise 1 introduction file (`Microsoft Team` → `Microsoft Teams`) and corrects callout block formatting to comply with Microsoft Learn style guidelines.

## Changes
- Fixed missing **s** in `Microsoft Teams` in both the YAML front-matter title and the H1 heading
- Corrected callout syntax from `>[!NOTE]` to `> [!NOTE]` (space after `>`) per Microsoft Learn alert block format
- Removed trailing blank lines at end of file

## Files changed
- `Instructions/Labs/M01-empower-workforce-copilot-executives/02-Ex1-introduction-synthesize-exercise.md` — fixed typo in title/heading, fixed callout formatting, removed trailing whitespace