### PR TITLE
style(m01/ex02): use straight apostrophes in exercise intro

### DIFF
--- a/Instructions/Labs/M01-empower-workforce-copilot-executives/07-Ex2-introduction-drive-exercise.md
+++ b/Instructions/Labs/M01-empower-workforce-copilot-executives/07-Ex2-introduction-drive-exercise.md
@@ -12,9 +12,9 @@ lab:
 
 # Exercise 2: Drive business outcomes using Microsoft 365 Copilot
 ---
-In today’s fast-paced business environment, executives are expected to make faster, smarter, and more strategic decisions, often with limited time and complex data. Microsoft 365 Copilot is designed to help leaders meet this challenge head-on. By combining the power of artificial intelligence with the familiarity of Microsoft 365 apps, Copilot enables executives to transform information into insight, streamline strategic planning, and focus their attention where it matters most: driving business outcomes.
+In today's fast-paced business environment, executives are expected to make faster, smarter, and more strategic decisions, often with limited time and complex data. Microsoft 365 Copilot is designed to help leaders meet this challenge head-on. By combining the power of artificial intelligence with the familiarity of Microsoft 365 apps, Copilot enables executives to transform information into insight, streamline strategic planning, and focus their attention where it matters most: driving business outcomes.
 
-For executives, Copilot serves as an intelligent partner that enhances decision-making, accelerates analysis, and automates routine work. Whether it’s summarizing market data in Word, forecasting financial trends in Excel, managing strategic initiatives in Planner, or communicating with clarity in Outlook, Copilot ensures leaders spend less time gathering information and more time acting on it.
+For executives, Copilot serves as an intelligent partner that enhances decision-making, accelerates analysis, and automates routine work. Whether it's summarizing market data in Word, forecasting financial trends in Excel, managing strategic initiatives in Planner, or communicating with clarity in Outlook, Copilot ensures leaders spend less time gathering information and more time acting on it.
 
 In this exercise, you step into the role of a Northwind Traders executive who plans to use Microsoft 365 Copilot to complete a series of high-impact tasks. Through these activities, you can see firsthand how Copilot and AI-powered assistants can elevate strategic thinking, improve organizational alignment, and help you deliver measurable results—faster and with greater confidence.
 
@@ -26,4 +26,3 @@ In this exercise, you step into the role of a Northwind Traders executive who pl
 You're the Chief Operating Officer (COO) of Northwind Traders, a mid-sized company specializing in specialty foods and beverages. Your role is to oversee operations, optimize cross-departmental projects, and provide strategic insights to the executive team. Today, you face a series of challenges that require rapid decision-making and strategic planning. Using Microsoft 365 Copilot, you plan to analyze data, create executive communications, manage projects, and gain insights to drive business outcomes.
 
 Your goal is to complete these critical tasks efficiently using Microsoft 365 Copilot in Office apps and agents. Each task simulates a real executive responsibility.
-


### PR DESCRIPTION
## Summary

Minor style cleanup in the Module 01 Exercise 2 introduction file: replaces two curly apostrophes with straight ASCII apostrophes to align with Microsoft Learn style guidance on straight quotes.

## Changes

- Replaced curly apostrophe (`’`) with straight apostrophe (`'`) in two prose sentences in the Exercise 2 introduction (`today's` and `it's`).

## Files changed

- `Instructions/Labs/M01-empower-workforce-copilot-executives/07-Ex2-introduction-drive-exercise.md` — straight-quote normalization in the two intro paragraphs; no content or step changes.