### PR TITLE
fix(lab01/ex02/t03): update planner steps for new create-a-plan dialog and copilot pane

### DIFF
--- a/Instructions/Labs/M01-empower-workforce-copilot-executives/10-Ex2-3-use-planner-create-project-plan.md
+++ b/Instructions/Labs/M01-empower-workforce-copilot-executives/10-Ex2-3-use-planner-create-project-plan.md
@@ -16,10 +16,7 @@ Northwind Traders is preparing to launch a new line of organic snacks—a cross-
 
 Perform the following steps to complete this task:
 
-1. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page, select **Apps** in the navigation pane, and then select **Teams** from the **Apps** menu.
-
-   > [!NOTE]
-   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Teams** from the list of apps that appears.
+1. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page, and select the **App Launcher** (grid icon), select **More Apps**, and then select **Teams** from the list of available apps.
 
 2. In the navigation pane in **Teams for the web**, select the **View more apps** (ellipsis) icon. In the menu that appears, select **Planner** if it appears in the apps window; otherwise, enter **Planner** in the **Search box** and then select **Planner** when it appears.
 

--- a/Instructions/Labs/M01-empower-workforce-copilot-executives/10-Ex2-3-use-planner-create-project-plan.md
+++ b/Instructions/Labs/M01-empower-workforce-copilot-executives/10-Ex2-3-use-planner-create-project-plan.md
@@ -11,36 +11,40 @@ lab:
 ---
 Northwind Traders is preparing to launch a new line of organic snacks—a cross-departmental effort involving marketing, production, and sales. As the executive sponsor, you’re responsible for ensuring the project stays aligned with company goals and is executed on time. In this task, you plan to use the AI Project Manager agent in Microsoft Planner to create, organize, and monitor the product launch plan. This scenario highlights how executives can use Copilot to oversee complex initiatives, promote collaboration, and maintain visibility into progress without getting lost in day-to-day details.
 
-> [!IMPORTANT] 
+> [!IMPORTANT]
 > Copilot in Planner first launched inside the Planner app in Microsoft Teams and has been progressively rolling out there. If you’re opening Planner on the web (planner.microsoft.com) or through older entry points, the Copilot button might not be present yet or it might require the plan to be set to Premium. For this training exercise, you should access the Planner app in Microsoft Teams.
 
 Perform the following steps to complete this task:
 
-1.  In your Microsoft Edge browser, go to the **Microsoft 365** home page, select **Apps** in the navigation pane, and then select **Teams** from the **Apps** menu.
+1. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page, select **Apps** in the navigation pane, and then select **Teams** from the **Apps** menu.
 
-2.  In the navigation pane in **Teams for the web**, select the **View more apps** (ellipsis) icon. In the menu that appears, select **Planner** if it appears in the apps window; otherwise, enter **Planner** in the **Search box** and then select **Planner** when it appears.
+   > [!NOTE]
+   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Teams** from the list of apps that appears.
 
-3.  On the **Planner** page, select **My Plans** in the navigation pane. On the **My Plans** page, select the **+New plan** button.
+2. In the navigation pane in **Teams for the web**, select the **View more apps** (ellipsis) icon. In the menu that appears, select **Planner** if it appears in the apps window; otherwise, enter **Planner** in the **Search box** and then select **Planner** when it appears.
 
-4.  In the **Create new** window, select the **Premium** tile. Note the description that appears for this tile – “Timeline, goals, and new AI features.”
+3. On the **Planner** page, select **My Plans** in the navigation pane. On the **My Plans** page, select the **+Create a plan** button.
 
-5.  In the **Create a premium plan from scratch** window, enter **New organic snack line** in the **Name** field. Leave the **Add to a group** field blank and select **Create**.
+4. In the **Create a plan** window, under **Start from scratch**, select the **Premium plan** tile. Note the description that appears for this tile – "Additional features for complex projects." Select **Create premium plan**.
 
-6.  In the Planner window for the **New organic snack line** plan, select the “**Chat with your AI Project Manager agent**” icon that appears in the bottom-right corner.
+5. In the **Create a plan** window, enter **New organic snack line** in the **Plan Name** field. Leave the **Share with your group** field blank and select **Create premium plan**.
 
-7.  The **Project Manager agent** pane that appears includes a **Create** prompt button, an **Ask** prompt button, several predefined prompts, and a manual prompt field. In this case, we want the agent to create a plan for Northwind’s new organic snack line, so select the **Create** button. Doing so inserts “**Build a plan for**” in the actual prompt field at the bottom of the pane. Next to this text, enter a description of the plan you want the agent to create.  
-    <br/>For this task, enter the following text after “Build a plan for”: **Northwind Traders’ new organic snack line. The plan should include tasks for Marketing, Production, Logistics, and Sales departments. Assign deadlines, owners, and dependencies.**
+6. In the Planner window for the **New organic snack line** plan, select the **Chat with Copilot** icon that appears in the bottom-right corner.
 
-8.  Review the suggested project plan. In the **Project Manager agent** pane, after Copilot’s note that it built the plan, select the **Go to Board** button. Review how the plan appears on the board. In our testing, the agent created other departments besides the ones mentioned in the prior prompt. Check to see if it created extra departments in your version as well. Feel free to add any tasks to each of the columns on the board.
+7. The **Copilot** pane that appears includes several predefined prompts and a prompt field. To have the agent create a plan for Northwind Traders' new organic snack line, select the **Build a plan for** suggested prompt. Selecting it inserts **Build a plan for** into the prompt field at the bottom of the pane. Next to this text, enter a description of the plan you want the agent to create.
 
-9.  Then select the **Go to Goals** button and review the results there. Make any adjustments as you see fit.
+    For this task, enter the following text after **Build a plan for**: `Northwind Traders' new organic snack line. The plan should include tasks for Marketing, Production, Logistics, and Sales departments. Assign deadlines, owners, and dependencies.`
 
-10. Ask the AI Project Manager agent if it can generate automated progress updates for stakeholders.
+8. Review the suggested project plan. In the **Copilot** pane, after Copilot's note that it built the plan, select the **Go to Board** button. Review how the plan appears on the board. In our testing, the agent created other departments besides the ones mentioned in the prior prompt. Check whether it created extra departments in your version as well. Feel free to add any tasks to the columns on the board.
+
+9. Then select the **Go to Goals** button and review the results there. Make any adjustments as you see fit.
+
+10. Ask the Copilot agent if it can generate automated progress updates for stakeholders.
 
 11. Review the response. Note the suggested prompts that are displayed above the prompt field. Test out these prompts.
 
-12. Ask the AI Project Manager agent to export a visual timeline of this project plan. You can then distribute this timeline to the Senior Leadership Team.
+12. Ask the Copilot agent to export a visual timeline of this project plan. You can then distribute this timeline to the Senior Leadership Team.
 
-13. After the agent generates the timeline, select the suggested prompt that tells it to provide a downloadable version of the timeline. If you don’t see this suggested prompt, then enter this request manually.  
-    <br/>Does your version of Planner display the image or allow you to download the PNG file? At the time of this writing, our version of Planner didn’t include the image or download link. However, since the AI Project Manager agent is a work in progress, this feature might be available at the time you perform this task. If so, download the timeline that was generated and save it to your OneDrive for use in Task 4.
+13. After the agent generates the timeline, select the suggested prompt that tells it to provide a downloadable version of the timeline. If you don't see this suggested prompt, enter this request manually.
 
+    Does your version of Planner display the image or allow you to download the PNG file? At the time of this writing, our version of Planner didn't include the image or download link. However, since the Copilot agent is a work in progress, this feature might be available at the time you perform this task. If so, download the timeline that was generated and save it to your OneDrive for use in Task 4.


### PR DESCRIPTION
## Summary

Updates Module 01, Exercise 2, Task 3 (`10-Ex2-3-use-planner-create-project-plan.md`) so the steps match the current Planner-in-Teams UI. The Create-a-plan dialog, the AI Project Manager pane (now branded **Copilot**), and several control labels have changed since the lab was written; this PR brings the instructions back in line with what learners see today and applies light Microsoft Learn style polish along the way.

## Changes

### Lab 01 / Exercise 2 / Task 3

- Step 1: Corrected the home page name to **Microsoft 365 Copilot** and rewrote the initial step to use **App Launcher**.
- Step 3: Renamed the button from **+New plan** to **+Create a plan**.
- Step 4: Updated the dialog (**Create new** to **Create a plan**), surfaced the new **Start from scratch** section, renamed **Premium** tile to **Premium plan**, updated the tile description to "Additional features for complex projects.", and added the new **Create premium plan** action.
- Step 5: Updated window title, field labels (**Plan Name**, **Share with your group**), and the create button to **Create premium plan**.
- Step 6: Renamed the launcher icon from **Chat with your AI Project Manager agent** to **Chat with Copilot**.
- Step 7: Rewrote for the new **Copilot** pane (no more dedicated **Create** / **Ask** buttons); learners now select the **Build a plan for** suggested prompt. Moved the example prompt body into a backtick code span and fixed the missing possessive in **Northwind Traders'**.
- Steps 8, 10, 12, 13: Replaced references to the **AI Project Manager agent** with **Copilot** / **Copilot agent** to match the rebranded pane.
- Style polish: switched smart quotes to straight quotes, removed `<br/>` tags inside list items, normalized list-item indentation/spacing, and removed a stray trailing space on the `[!IMPORTANT]` callout.

## Files changed

- `Instructions/Labs/M01-empower-workforce-copilot-executives/10-Ex2-3-use-planner-create-project-plan.md` - Reworked steps 1, 3-8, 10, 12, and 13 to match the current Planner-in-Teams UI and applied Microsoft Learn style polish.
