### PR TITLE
Fix #35: Confirm GitHub Pages setup and exercise file naming

### DIFF
--- a/Instructions/Demos/DEMO_deploying_an_arm_template.md
+++ b/Instructions/Demos/DEMO_deploying_an_arm_template.md
@@ -40,4 +40,4 @@ demo:
 
     - Etiam rutrum pretium enim. 
 
-1. Curabitur in pretium urna, nec ullamcorper diam. 
+1. Curabitur in pretium urna, nec ullamcorper diam.


### PR DESCRIPTION
## Description

This PR addresses issue #35 regarding GitHub Pages setup and markdown file organization.

Fixes #35

## Changes / Findings

- **GitHub Pages is already enabled** for this repository. The online hosted instructions are available at: [Online Hosted Instructions | MS-4004-Empower-workforce-copilot-use-cases](https://microsoftlearning.github.io/MS-4004-Empower-workforce-copilot-use-cases/)
- **The markdown files are already named with exercise grouping prefixes**, so they are correctly organized for the hosted site.
<img width="584" height="351" alt="image" src="https://github.com/user-attachments/assets/bc70ef89-4e23-411a-a6f2-51aff41fd91a" />

## Notes

No further changes are required for the items raised in issue #35 as both requirements are already satisfied in the current repository state.