### PR TITLE
fix(ms-4004/lab05): update lab setup for current M365 Copilot UI and style

### DIFF
--- a/Instructions/Labs/M05-empower-workforce-copilot-finance/01-introduction.md
+++ b/Instructions/Labs/M05-empower-workforce-copilot-finance/01-introduction.md
@@ -14,36 +14,38 @@ lab:
 
 In this module, we'll create prompts for Microsoft 365 Copilot that reference files. First, let’s upload all required files to OneDrive to ensure they're accessible throughout the lab.
 
-
-### Uploading Files to OneDrive
+### Uploading files to OneDrive
 
 Follow the steps below to upload all files needed to **OneDrive**:
 
 1. Log into the virtual machine provided by your tenant provider as the local **Administrator** account with the password `Pa55w.rd`.
 2. In the Windows taskbar, select **Microsoft Edge**.
-3. In the address bar, enter `https://www.office.com`.
-4. Under **Welcome to Microsoft 365**, select **Sign in**.
-5. At the **Sign-in prompt**, enter `userx@yourtenant.onmicrosoft.com` (username and tenant provided by your tenant provided) and select **Next**.
+3. In the address bar, enter `https://m365.cloud.microsoft.com`.
+4. On the Microsoft 365 Copilot landing page, select **Sign in**.
+5. At the **Sign-in prompt**, enter `userx@yourtenant.onmicrosoft.com` (username and tenant provided by your tenant provider) and select **Next**.
 6. At the **Enter password** screen, enter the password (provided by tenant provider) for the User account, then select **Sign in**.
 7. If prompted to **Stay signed in**, select **Don't show this again** and then **Yes**.
-8. In **Microsoft 365**, select **Apps**.
+8. In **Microsoft 365 Copilot**, select **Apps**.
+   > [!NOTE]
+   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **OneDrive** from the list of apps that appears.
+
 9. Within **Apps**, select **OneDrive**.
-10. In **OneDrive**, in the top-left corner, select **+** (add new) > **File upload**.
+10. In **OneDrive**, in the top-left corner, select **+ Create or upload** > **Files upload**.
 11. In **File Explorer**, select **This PC** > **Local Disk (C:)** and open the **ResourceFiles** folder.
 12. Select all files within the **ResourceFiles** folder, then select **Open** to upload them to **OneDrive**.
-13. When the upload is complete, you should see **Uploaded 29 items to My files** in the bottom center of the screen.
+13. When the upload is complete, you should see **Uploaded 92 items to My files** in the bottom center of the screen.
 14. Leave **Edge** open and move on to the next task.
 
-### Referencing Files in Copilot
+### Referencing files in Copilot
 
-When using Copilot, you may find that some files aren’t immediately available in the suggestions. This occurs because certain Copilot experiences only reference files from the **Most Recently Used (MRU)** list, while others let you browse **OneDrive** directly. To ensure a file appears in the **MRU** list, simply open it in the relevant Microsoft 365 app, and it will be added automatically.
+When using Copilot, you may find that some files aren’t immediately available in the suggestions. This occurs because certain Copilot experiences only reference files from the **Most Recently Used (MRU)** list, while others let you browse **OneDrive** directly. To ensure a file appears in the **MRU** list, open it in the relevant Microsoft 365 app, and it will be added automatically.
 
 > [!IMPORTANT]
 > Microsoft 365 Copilot can only work with files saved to **OneDrive**. Files stored locally on your PC will need to be moved to **OneDrive** for Copilot to access them.
 
 # Introduction
 ---
-By using Microsoft 365 Copilot, Finance professionals can save time and effort, streamline their work, and make informed decisions based on data insights. This module equips Finance professionals with the skills and knowledge necessary to use Microsoft 365 Copilot to streamline your workflow and enhance your productivity. 
+By using Microsoft 365 Copilot, Finance professionals can save time and effort, streamline their work, and make informed decisions based on data insights. This module equips Finance professionals with the skills and knowledge necessary to use Microsoft 365 Copilot to streamline their workflow and enhance productivity.
 
 As a Finance professional, your ability to effectively use Microsoft 365 Copilot is crucial for:
 
@@ -81,5 +83,4 @@ One of the primary keys to effectively using Copilot is the quality of your Copi
 
 - **Expectations**. Define how you want the response delivered—tone, style, or level of detail. For example: “Use simple language so I can get up to speed quickly” or “Explain it as if I were a pirate.”
 
-
-Keep these four elements front and center as you practice creating prompts—they’re the foundation for getting clear, accurate, and useful results from Copilot. Implementing these elements as you write prompts in these exercises can build real-world skills, so writing effective prompts becomes second nature.
+Keep these four elements in mind as you practice creating prompts—they're the foundation for getting clear, accurate, and useful results from Copilot. Applying these elements as you write prompts in these exercises builds real-world skills, so writing effective prompts becomes second nature.

--- a/Instructions/Labs/M05-empower-workforce-copilot-finance/01-introduction.md
+++ b/Instructions/Labs/M05-empower-workforce-copilot-finance/01-introduction.md
@@ -20,7 +20,7 @@ Follow the steps below to upload all files needed to **OneDrive**:
 
 1. Log into the virtual machine provided by your tenant provider as the local **Administrator** account with the password `Pa55w.rd`.
 2. In the Windows taskbar, select **Microsoft Edge**.
-3. In the address bar, enter `https://m365.cloud.microsoft.com`.
+3. In the address bar, enter `https://www.office.com`.
 4. On the Microsoft 365 Copilot landing page, select **Sign in**.
 5. At the **Sign-in prompt**, enter `userx@yourtenant.onmicrosoft.com` (username and tenant provided by your tenant provider) and select **Next**.
 6. At the **Enter password** screen, enter the password (provided by tenant provider) for the User account, then select **Sign in**.


### PR DESCRIPTION
## Summary

Updates the Lab 05 (Finance) setup instructions to reflect the current Microsoft 365 Copilot portal UI and applies Microsoft Learn style fixes throughout the introduction page.

## Changes

- Updated sign-in step to match current M365 Copilot landing page
- Fixed typo: 'tenant provided' to 'tenant provider' in step 5
- Updated step 8 to reference **Microsoft 365 Copilot** and added NOTE fallback for App Launcher navigation
- Updated OneDrive upload button label to **+ Create or upload** > **Files upload**
- Updated file count from 29 to 92 to match current ResourceFiles content
- Applied sentence case to section headings
- Removed filler word 'simply' from Referencing files section
- Fixed person inconsistency: 'your workflow' to 'their workflow' (subject is 'Finance professionals')
- Replaced colloquial phrasing in closing paragraph
- Removed extra blank lines and trailing whitespace

## Files changed

- `Instructions/Labs/M05-empower-workforce-copilot-finance/01-introduction.md` — Updated lab setup steps for current UI, applied style and grammar fixes