### PR TITLE
style(m05/ex01): replace smart apostrophes with straight quotes

### DIFF
--- a/Instructions/Labs/M05-empower-workforce-copilot-finance/02-Ex1-introduction-optimize-reporting-exercise.md
+++ b/Instructions/Labs/M05-empower-workforce-copilot-finance/02-Ex1-introduction-optimize-reporting-exercise.md
@@ -12,7 +12,7 @@ lab:
 
 # Exercise 1: Optimize financial reporting and acquisition modeling using Microsoft 365 Copilot
 ---
-In today’s fast-paced business environment, financial analysts play a critical role in shaping organizational strategy. They turn data into insights, evaluate investment opportunities, and guide executives toward sound financial decisions. However, much of a financial analyst’s day is still consumed by manual tasks, such as cleaning and organizing data, creating reports, summarizing meeting notes, and preparing presentations for leadership.
+In today's fast-paced business environment, financial analysts play a critical role in shaping organizational strategy. They turn data into insights, evaluate investment opportunities, and guide executives toward sound financial decisions. However, much of a financial analyst's day is still consumed by manual tasks, such as cleaning and organizing data, creating reports, summarizing meeting notes, and preparing presentations for leadership.
 
 Microsoft 365 Copilot transforms how financial analysts work by embedding AI assistance directly into the tools they use every day, such as Excel, Teams, PowerPoint, and Copilot Chat. Instead of spending hours manipulating data or drafting content, analysts can ask Copilot to automate routine steps, generate summaries, and visualize insights instantly. This shift allows them to focus on what matters most: interpreting results, identifying trends, and driving strategic recommendations.
 
@@ -23,11 +23,10 @@ For financial professionals at Fabrikam, Inc., Copilot acts as a digital partner
 
 ### Scenario
 
-In this exercise, you take on the role of a Financial Analyst at Fabrikam, Inc. Fabrikam is a global manufacturer of sustainable consumer products. It’s currently in the midst of two major initiatives: 
+In this exercise, you take on the role of a Financial Analyst at Fabrikam, Inc. Fabrikam is a global manufacturer of sustainable consumer products. It's currently in the midst of two major initiatives:
 
 - Launching a new product line.
 
-- Exploring a potential acquisition of Relecloud, a technology company that would expand Fabrikam’s digital product portfolio.
+- Exploring a potential acquisition of Relecloud, a technology company that would expand Fabrikam's digital product portfolio.
 
 One of your key priorities is to help leadership make informed business decisions. Towards that end, you plan to use Copilot to analyze financial data, prepare acquisition summaries, and ensure reporting requirements are up to date. Throughout this exercise, you use Microsoft 365 Copilot across Excel, Teams, PowerPoint, and Copilot Chat to streamline your daily work, improve collaboration, and present data-driven insights more efficiently. Each task in this exercise builds upon the last, simulating a realistic workflow for a financial analyst.
-


### PR DESCRIPTION
## Summary

Fixes smart-quote apostrophes in the Module 5 Exercise 1 introduction so the prose uses straight quotes per Microsoft Learn style.

## Changes

### M05 — Empower workforce with Copilot (Finance)

- Replaced four curly apostrophes with straight apostrophes (`'`) in the Exercise 1 introduction: `today's`, `analyst's`, `It's`, and `Fabrikam's`.

## Files changed

- `Instructions/Labs/M05-empower-workforce-copilot-finance/02-Ex1-introduction-optimize-reporting-exercise.md` — replaced smart apostrophes with straight quotes in the intro and scenario paragraphs.
