### PR TITLE
fix(m05/ex01/t01): update sign-in URL and Copilot pane steps for current UI

### DIFF
--- a/Instructions/Labs/M05-empower-workforce-copilot-finance/03-Ex1-1-use-excel-analyze-product-line.md
+++ b/Instructions/Labs/M05-empower-workforce-copilot-finance/03-Ex1-1-use-excel-analyze-product-line.md
@@ -22,7 +22,7 @@ This task reflects how financial analysts actually work, focusing on both insigh
 Excel provides two ways to use Copilot: standard Copilot prompts for asking questions and getting insights about the data in the workbook, and **Edit with Copilot** in the Copilot pane for making direct, in‑place changes to worksheets, tables, and formulas.
 
 - You should use Copilot’s standard prompts in Excel for quick questions, simple summaries, or one‑off insights about the data you’re already viewing. When using the Copilot pane, if you enter a prompt without selecting **Edit with Copilot**, Copilot responds in a chat‑style mode that generates suggestions or content separately, rather than making direct, in‑place changes to the workbook.  
-    
+
 - You should use **Edit with Copilot** when you want Copilot to work directly with the worksheet—such as cleaning data, adding formulas, restructuring tables, or making iterative, in‑place changes. **Edit with Copilot** is designed for hands‑on data work, so it understands the structure of the sheet and can apply changes directly, rather than just describing what you could do.
 
 In summary, use chat‑style Copilot for thinking and generating ideas; use **Edit with Copilot** for hands‑on editing inside the file. **Edit with Copilot** proposes specific changes (formulas, columns, cleanup steps) and, once you confirm, it applies those changes directly to the worksheet rather than expecting the user to explicitly apply them through copy and paste.  
@@ -31,33 +31,38 @@ This task uses the **Edit with Copilot** functionality.
 
 In addition, Copilot for Excel provides a response control selector that lets you choose which AI model Copilot uses to work with your workbook. You can leave this set to **Auto** (the default option) and let Copilot select a model for you, or choose a specific model when you want to influence how Copilot approaches the task.
 
-If you’ve used Copilot Chat, you know that it also includes a response control selector. However, its options are different from the Excel selector. In Copilot Chat, the selector controls how deeply Copilot reasons about your request. In Excel, the selector controls which AI model performs the work. Although these selectors might appear to be similar, they control different aspects of Copilot and aren't the same setting.
+If you’ve used Copilot Chat, you know that it also includes a response control selector. However, its options are different from those of the Excel selector. In Copilot Chat, the selector controls how deeply Copilot reasons about your request. In Excel, the selector controls which AI model performs the work. Although these selectors might appear to be similar, they control different aspects of Copilot and aren't the same setting.
 
 This task uses the default **Auto** selector mode.
 
 Perform the following steps to complete this task:
 
-1.  Select the following link to download the [**EcoSmart COGS Estimates.xlsx**](https://go.microsoft.com/fwlink/?linkid=2347616) file. Store the file in your OneDrive account for use by Copilot in your tenant.
+1. Select the following link to download the [**EcoSmart COGS Estimates.xlsx**](https://go.microsoft.com/fwlink/?linkid=2347616) file. Store the file in your OneDrive account for use by Copilot in your tenant.
 
-2.  In your Microsoft Edge browser, sign in to the **Microsoft 365** home page **(https://www.microsoft365.com)**, select **Apps** in the navigation pane, and then select **Excel** from the **Apps** menu.
+2. In your Microsoft Edge browser, sign in to the **Microsoft 365 Copilot** home page [**https://m365.cloud.microsoft.com**](https://m365.cloud.microsoft.com), select **Apps** in the navigation pane, and then select **Excel** from the **Apps** menu.
 
-3.  In **Excel for the web**, select the **Upload a file** button, navigate to your OneDrive, and then select the **EcoSmart COGS Estimates** spreadsheet.
+   > [!NOTE]
+   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Excel** from the list of apps that appears.
 
-4.  On the **Home** tab ribbon, select **Copilot**. In the Copilot pane, leave the response mode selector set to **Auto**. Then verify the **Edit with Copilot** icon appears in the prompt field next to the plus (+) sign. If you don’t see it, select the plus sign and then select **Edit with Copilot** in the drop-down menu. The icon should now appear in the prompt field.
+3. In **Excel for the web**, select the **Upload a file** button, navigate to your OneDrive, and then select the **EcoSmart COGS Estimates** spreadsheet.
 
-5.  In the Copilot pane, ask Copilot to analyze the data to help you understand the dataset. Submit the following prompt:
+4. In the bottom-right corner of the document, select the **Copilot** icon to open the Copilot pane. In the Copilot pane, leave the response mode selector set to **Auto**. Verify the pane opens in edit mode—the heading should read **Let's edit your workbook**, and the prompt field should display the placeholder text **Describe what you'd like to edit**. Below the heading, confirm that the mode selector is set to **Allow editing** (so Copilot can edit your workbook directly). If it shows **Chat only**, select the drop-down and then select **Allow editing**.
+
+5. In the Copilot pane, ask Copilot to analyze the data to help you understand the dataset. Submit the following prompt:
   
    > [!NOTE]
-   > For this first prompt, we’ve provided the text so you can see what an effective prompt looks like when it incorporates the four key elements discussed in the Introduction unit. You must write all remaining prompts in this exercise, but in doing so, you can use this prompt as a model to emulate._
+   > For this first prompt, we’ve provided the text so you can see what an effective prompt looks like when it incorporates the four key elements discussed in the Introduction unit. You must write all remaining prompts in this exercise, but in doing so, you can use this prompt as a model to emulate.
 
-   **I’m a financial analyst for Fabrikam. I was asked to analyze the EcoSmart COGS Estimates spreadsheet for Fabrikam’s new EcoSmart product line. Can you please review the dataset in this spreadsheet and provide two things in a new sheet: (1) a clear description of each key column and its purpose, and (2) a list of any missing or inconsistent data points that could affect accuracy. Present your findings in a concise, structured format in a new sheet.**
+   `I'm a financial analyst for Fabrikam. I was asked to analyze the EcoSmart COGS Estimates spreadsheet for Fabrikam’s new EcoSmart product line. Can you please review the dataset in this spreadsheet and provide two things in a new sheet: (1) a clear description of each key column and its purpose, and (2) a list of any missing or inconsistent data points that could affect accuracy. Present your findings in a concise, structured format in a new sheet.`
 
-6.  Review the results in the new sheet and then select **Sheet1** to return to the dataset. Your next task is to identify cost trends. Ask Copilot to find patterns in the data and summarize which product features or components have the highest average COGS. Ask it to return the results in a new sheet.
+6. Review the results in the new sheet and then select **Sheet1** to return to the dataset. Your next task is to identify cost trends. Ask Copilot to find patterns in the data and summarize which product features or components have the highest average COGS. Ask it to return the results in a new sheet.
 
-7.  Review the results in the new sheet containing a COGS pattern analysis. Stay in this sheet for this next request. You now want Copilot to identify any anomalies in the COGS data. Ask Copilot to look for any outliers or anomalies in the COGS data that could indicate data errors or unusually high material costs. Ask it to return the results in a new sheet.
+7. Review the results in the new sheet containing a COGS pattern analysis. Stay in this sheet for this next request. You now want Copilot to identify any anomalies in the COGS data. Ask Copilot to look for any outliers or anomalies in the COGS data that could indicate data errors or unusually high material costs. Ask it to return the results in a new sheet.
 
-8.  Review the results in the new sheet containing the outlier analysis and then select **Sheet1** to return to the dataset. You now want to ask Copilot to generate a brief summary report of the top three cost drivers and any opportunities to reduce costs. Ask it to return the results in a new sheet.
+8. Review the results in the new sheet containing the outlier analysis and then select **Sheet1** to return to the dataset. You now want to ask Copilot to generate a brief summary report of the top three cost drivers and any opportunities to reduce costs. Ask it to return the results in a new sheet.
 
-9.  Review the results in the new sheet containing the cost driver summary and then select **Sheet1** to return to the dataset. Finally, ask Copilot to create a bar chart that shows the top five product features by average COGS. Ask it to return the results in a new sheet.
+9. Review the results in the new sheet containing the cost driver summary and then select **Sheet1** to return to the dataset. Finally, ask Copilot to create a bar chart that shows the top five product features by average COGS. Ask it to return the results in a new sheet.
 
-10.  You plan to reference these findings in a future meeting with your Finance Manager to discuss next steps.
+10. In the Copilot pane, review the generated chart on the new sheet and then select **Done** to keep Copilot's changes to the workbook.
+
+11. You plan to reference these findings in a future meeting with your Finance Manager to discuss next steps.

--- a/Instructions/Labs/M05-empower-workforce-copilot-finance/03-Ex1-1-use-excel-analyze-product-line.md
+++ b/Instructions/Labs/M05-empower-workforce-copilot-finance/03-Ex1-1-use-excel-analyze-product-line.md
@@ -39,10 +39,7 @@ Perform the following steps to complete this task:
 
 1. Select the following link to download the [**EcoSmart COGS Estimates.xlsx**](https://go.microsoft.com/fwlink/?linkid=2347616) file. Store the file in your OneDrive account for use by Copilot in your tenant.
 
-2. In your Microsoft Edge browser, sign in to the **Microsoft 365 Copilot** home page [**https://m365.cloud.microsoft.com**](https://m365.cloud.microsoft.com), select **Apps** in the navigation pane, and then select **Excel** from the **Apps** menu.
-
-   > [!NOTE]
-   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Excel** from the list of apps that appears.
+2. In your Microsoft Edge browser, sign in to the **Microsoft 365 Copilot** home page [**https://m365.cloud.microsoft.com**](https://m365.cloud.microsoft.com) and select the **App Launcher** (grid icon), select **More Apps**, and then select **Excel** from the list of available apps.
 
 3. In **Excel for the web**, select the **Upload a file** button, navigate to your OneDrive, and then select the **EcoSmart COGS Estimates** spreadsheet.
 


### PR DESCRIPTION
## Summary

Updates Module 5 Exercise 1 Task 1 (Use Copilot in Excel to analyze new product line COGS) so the instructions match the current Microsoft 365 Copilot and Excel for the web UI.

## Changes

### M05 — Empower workforce with Copilot (Finance) — Exercise 1, Task 1

- Updated the sign-in URL from `microsoft365.com` to `m365.cloud.microsoft.com` (step 2).
- Added an `[!NOTE]` callout for step 2 explaining how to reach Excel through the **App Launcher** if **Apps** isn't visible in the navigation pane.
- Rewrote step 4 to reflect the current Excel Copilot pane: open Copilot from the bottom-right icon, verify the pane opens in edit mode (**Let's edit your workbook** heading, **Describe what you'd like to edit** placeholder), and switch the mode selector from **Chat only** to **Allow editing** if needed.
- Replaced the bold sample prompt in step 5 with a backticked code string per Microsoft Learn style (typed values use backticks, not bold).
- Added the missing step 10 — review the generated chart and select **Done** to keep Copilot's changes — and renumbered the closing note to step 11.
- Normalized numbered-list indentation (`1.  ` → `1. `).
- Grammar: "different from the Excel selector" → "different from those of the Excel selector"; removed a stray trailing underscore in the step 5 `[!NOTE]`.

## Files changed

- `Instructions/Labs/M05-empower-workforce-copilot-finance/03-Ex1-1-use-excel-analyze-product-line.md` — UI drift updates for the Microsoft 365 Copilot sign-in URL, Excel Copilot pane steps, missing **Done** step, list formatting, and minor grammar fixes.
