### PR TITLE
style(lab05/ex01/t03): apply Microsoft Learn style and grammar fixes

### DIFF
--- a/Instructions/Labs/M05-empower-workforce-copilot-finance/05-Ex1-3-use-chat-analyze-potential-acquisition.md
+++ b/Instructions/Labs/M05-empower-workforce-copilot-finance/05-Ex1-3-use-chat-analyze-potential-acquisition.md
@@ -1,7 +1,7 @@
 ---
 lab:
   title: 'Exercise 1, Task 3: Use Copilot Chat to analyze a potential acquisition'
-  description: '<br/This time, ask Copilot to create an expanded version of this previous report. Tell it to include all the information that was in the previous summary, since you don’t want to lose any of that data. But this time, also add the following information:'
+  description: 'This time, ask Copilot to create an expanded version of this previous report. Tell it to include all the information that was in the previous summary, since you don’t want to lose any of that data. But this time, also add the following information:'
   duration: 22 minutes
   level: 100
   islab: true
@@ -9,7 +9,7 @@ lab:
 
 # Exercise 1, Task 3: Use Copilot Chat to analyze a potential acquisition
 ---
-Fabrikam’s executive team is evaluating the potential acquisition of Relecloud, Ltd. Robin Kline, Fabrikam’s Finance Manager, sent you a detailed business perspective for Relecloud. It provides an overview of the company’s market position and industry analysis, financial performance, customer and sales insights, operations and capabilities, intellectual property, product roadmap, risks and challenges, and future outlook. 
+Fabrikam’s executive team is evaluating the potential acquisition of Relecloud, Ltd. Robin Kline, Fabrikam's Finance Manager, sent you a detailed business perspective for Relecloud. It provides an overview of the company’s market position and industry analysis, financial performance, customer and sales insights, operations and capabilities, intellectual property, product roadmap, risks and challenges, and future outlook.
 
 Robin tasked you with analyzing and summarizing the document into three concise areas:
 
@@ -25,40 +25,40 @@ This exercise demonstrates how Copilot Chat can extract, categorize, and structu
 
 In Copilot Chat on the web, the response mode selector lets you control how much time and reasoning Copilot uses when answering your prompt. You can leave it set to **Auto** (the default option) so Copilot balances speed and depth for you, or choose a faster or more in‑depth response style depending on the task.
 
-When Copilot Chat opens in **Work** mode, the response mode selector isn’t shown. In **Work** mode, Copilot is optimized for secure, work‑context queries, so it automatically manages response depth for you. When you switch to **Web** mode, the response mode selector appears, allowing you to choose between faster responses or deeper reasoning. Once the selector is enabled, it remains visible as you switch between **Work** and **Web** modes.  
+When Copilot Chat opens in **Work** mode, the response mode selector isn't shown. In **Work** mode, Copilot is optimized for secure, work-context queries, so it automatically manages response depth for you. When you switch to **Web** mode, the response mode selector appears, allowing you to choose between faster responses or deeper reasoning. Once the selector is enabled, it remains visible as you switch between **Work** and **Web** modes.
 
-As you saw in the earlier task that used Copilot in Excel, you know that it also includes a response control selector. However, its options are different from the Chat selector. In Copilot Chat, the selector controls how deeply Copilot reasons about your request. In Excel, the selector controls which AI model performs the work. Although these selectors may look similar, they control different aspects of Copilot and aren't the same setting.
+As you saw in the earlier task that used Copilot in Excel, Copilot also includes a response control selector. However, its options differ from the Chat selector. In Copilot Chat, the selector controls how deeply Copilot reasons about your request. In Excel, the selector controls which AI model performs the work. Although these selectors may look similar, they control different aspects of Copilot and aren't the same setting.
 
 Perform the following steps to complete this task:
 
-1.  Select the following link to download the [**Relecloud Business Perspective.docx**](https://go.microsoft.com/fwlink/?linkid=2347813) file. Store the file in your OneDrive account for use by Copilot in your tenant.
+1. Select the following link to download the [**Relecloud Business Perspective.docx**](https://go.microsoft.com/fwlink/?linkid=2347813) file. Store the file in your OneDrive account for use by Copilot in your tenant.
 
-2.  In your Microsoft Edge browser, go to the **Microsoft 365** home page. Since this task involves reviewing a file uploaded to OneDrive and generating insights from that internal document, select the **Work** option. The **Web** option doesn’t apply here, since it searches external sources like public websites and blogs.
+2. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page. Since this task involves reviewing a file uploaded to OneDrive and generating insights from that internal document, select **Work**. The **Web** option doesn't apply here, since it searches external sources like public websites and blogs.
 
-3.  In the Copilot prompt field, attach the **Relecloud Business Perspective.docx** file that you downloaded in step 1. Based off of Robin Kline’s request, ask Copilot to review the attached document and create a business perspective summary that contains the following three sections: Relecloud’s financial data, Operations analysis of Relecloud, and Integration plan for the acquisition.
+3. In the Copilot prompt field, attach the **Relecloud Business Perspective.docx** file that you downloaded in step 1. Based on Robin Kline's request, ask Copilot to review the attached document and create a business perspective summary that contains the following three sections: Relecloud's financial data, Operations analysis of Relecloud, and Integration plan for the acquisition.
 
-4.  Upon reviewing the results, you feel that Copilot’s summary was a good start, but it didn’t get into the level of detail that you feel is necessary for a comprehensive analysis of Relecloud’s business. In looking at your previous prompt, you simply asked for a summary containing three sections, but you didn’t provide any details as to what you really wanted Copilot to include in those sections. When you leave those types of decisions up to Copilot, its results might not always meet your expectations.  
-    <br/>This time, ask Copilot to create an expanded version of this previous report. Tell it to include all the information that was in the previous summary, since you don’t want to lose any of that data. But this time, also add the following information:  
+4. Upon reviewing the results, you feel that Copilot's summary was a good start, but it didn't get into the level of detail that you feel is necessary for a comprehensive analysis of Relecloud's business. In looking at your previous prompt, you asked for a summary containing three sections, but you didn't provide any details as to what you really wanted Copilot to include in those sections. When you leave those types of decisions up to Copilot, its results might not always meet your expectations.
+
+    This time, ask Copilot to create an expanded version of this previous report. Tell it to include all the information that was in the previous summary, since you don't want to lose any of that data. But this time, also add the following information:
     - In the **Financial analysis** section, include:
         - Valuation and deal structure, including valuation multiples and deal structure implications
         - Financial health and ratios, including liquidity and solvency, profitability trends, gross-to-net retention by cohort, regional annual recurring revenue (ARR) dynamics, and cash flow analysis
         - Revenue and customer concentration, including revenue breakdown, customer concentration risk, customer concentration by sector/vertical, and churn and retention drivers
         - The following visual:
-            - **Line or Bar Charts:** Revenue, earnings before interest, taxes, depreciation, and amortization (EBITDA), and net income trends over time, plus gross margin and operating margin trends.  
-                
+            - **Line or Bar Charts:** Revenue, earnings before interest, taxes, depreciation, and amortization (EBITDA), and net income trends over time, plus gross margin and operating margin trends.
+
     - In the **Operations analysis** section, include:
         - Cost structure and efficiency, including COGS and operating expenses (OpEx) analysis, efficiency metrics, and scalability assessment
         - Competitive positioning, including strengths, weaknesses, opportunities, and threats (SWOT) analysis and peer benchmarking
         - The following visuals:
             - **SWOT Matrix:** Visual grid summarizing strengths, weaknesses, opportunities, and threats.
-            - **Scalability Assessment Diagram:** Illustrates development, security, and operations (DevSecOps) practices, infrastructure, and organizational scalability.  
-                
+            - **Scalability Assessment Diagram:** Illustrates development, security, and operations (DevSecOps) practices, infrastructure, and organizational scalability.
+
     - In the **Integration Planning** section, include:
         - Synergy and integration modeling, including synergy realization, integration risks, and a post-merger integration plan
-        - Leadership and Organizational review, including management track record and organizational structure
+        - Leadership and organizational review, including management track record and organizational structure
         - The following visual:
-            - **Integration Timeline (Gantt Chart):** Visualizes the phases and milestones of the post-merger integration plan.  
- 
-5.  Review the results. Note the difference between Copilot’s first summary report that was based on a high-level prompt, and this second summary report that was based on a much more detailed request. This exercise shows the importance of a detailed prompt that includes the four key elements of an effective prompt.
+            - **Integration Timeline (Gantt Chart):** Visualizes the phases and milestones of the post-merger integration plan.
+5. Review the results. Note the difference between Copilot’s first summary report that was based on a high-level prompt, and this second summary report that was based on a much more detailed request. This exercise shows the importance of a detailed prompt that includes the four key elements of an effective prompt.
 
-6.  Feel free to select any of Copilot’s suggested prompts if you want to update the summary even further. When you’re ready, ask Copilot to compile this information into a single downloadable document. Download the file once it’s generated and store it in your OneDrive account.
+6. Feel free to select any of Copilot's suggested prompts if you want to update the summary further. When you're ready, ask Copilot to compile this information into a single downloadable document. Download the file once it's generated and store it in your OneDrive account.

--- a/Instructions/Labs/M05-empower-workforce-copilot-finance/05-Ex1-3-use-chat-analyze-potential-acquisition.md
+++ b/Instructions/Labs/M05-empower-workforce-copilot-finance/05-Ex1-3-use-chat-analyze-potential-acquisition.md
@@ -23,9 +23,7 @@ This exercise demonstrates how Copilot Chat can extract, categorize, and structu
 
 #### Using Copilot Chat
 
-In Copilot Chat on the web, the response mode selector lets you control how much time and reasoning Copilot uses when answering your prompt. You can leave it set to **Auto** (the default option) so Copilot balances speed and depth for you, or choose a faster or more in‑depth response style depending on the task.
-
-When Copilot Chat opens in **Work** mode, the response mode selector isn't shown. In **Work** mode, Copilot is optimized for secure, work-context queries, so it automatically manages response depth for you. When you switch to **Web** mode, the response mode selector appears, allowing you to choose between faster responses or deeper reasoning. Once the selector is enabled, it remains visible as you switch between **Work** and **Web** modes.
+In Copilot Chat on the web, the response mode selector lets you control how much time and reasoning Copilot uses when answering your prompt. You can leave it set to **Auto** (the default option) so Copilot balances speed and depth for you, or choose a faster or more in-depth response style depending on the task. The response mode selector is visible in both **Work** and **Web** modes.
 
 As you saw in the earlier task that used Copilot in Excel, Copilot also includes a response control selector. However, its options differ from the Chat selector. In Copilot Chat, the selector controls how deeply Copilot reasons about your request. In Excel, the selector controls which AI model performs the work. Although these selectors may look similar, they control different aspects of Copilot and aren't the same setting.
 


### PR DESCRIPTION
## Summary

This pull request applies Microsoft Learn style and grammar fixes to the lab instructions for Exercise 1, Task 3 (Use Copilot Chat to analyze a potential acquisition). The updates improve readability, correct a malformed HTML tag in the front matter description, standardize typography (straight vs. curly apostrophes), and refine wording to better align with Microsoft Learn editorial style.

## Changes

- Fixed a malformed `<br/` tag in the front matter `description` field so the YAML metadata renders cleanly.

- Replaced curly apostrophes with straight apostrophes in several places for consistency (for example, isn't, don't, didn't, Robin Kline's, Copilot's, Relecloud's).

- Reworded the reference to the Microsoft 365 home page to Microsoft 365 Copilot home page for accuracy, and simplified Select the Work option to Select Work.

- Updated Based off of to Based on for correct preposition usage.

- Adjusted minor phrasing (for example, also includes to Copilot also includes, are different from to differ from, you simply asked to you asked, even further to further) to tighten the prose.

- Moved the This time, ask Copilot... instruction out of an inline `<br/>` block into its own paragraph for better readability and Markdown rendering.

- Reformatted nested bullet lists by removing extra blank lines between sub-items so they render as a single cohesive list.

- **Exercise 1, Task 3 (Lab 05):** Removed outdated paragraph stating the response mode selector is hidden in Work mode. The selector is now visible in both Work and Web modes, matching the current Copilot Chat UI. (Fixes #41)

## Files changed

`Instructions/Labs/M05-empower-workforce-copilot-finance/05-Ex1-3-use-chat-analyze-potential-acquisition.md`

Fix #41 