### PR TITLE
fix(lab05/ex01/t04): update Copilot in Excel prompt and pane instructions

### DIFF
--- a/Instructions/Labs/M05-empower-workforce-copilot-finance/06-Ex1-4-use-excel-model-scenarios.md
+++ b/Instructions/Labs/M05-empower-workforce-copilot-finance/06-Ex1-4-use-excel-model-scenarios.md
@@ -1,7 +1,7 @@
 ---
 lab:
   title: 'Exercise 1, Task 4: Use Copilot in Excel to model What-If scenarios'
-  description: Let's begin by requesting the what-if scenario. Ask Copilot to update the Relecloud acquisition financials to reflect a 1x increase in the earnings before interest, taxes, depreciation, and amortization (EBITDA) multiple and a 20% increase in synergy savings.
+  description: Let's begin by requesting the what-if scenario. Ask Copilot to create a what-if scenario that doubles each EBITDA value and increases synergy savings midpoints by 20%.
   duration: 42 minutes
   level: 100
   islab: true
@@ -18,36 +18,41 @@ This task showcases Copilot’s ability to perform dynamic modeling and visualiz
 
 Perform the following steps to complete this task:
 
-1.  Select the following link to download the [**Relecloud Acquisition Financials.xlsx**](https://go.microsoft.com/fwlink/?linkid=2347812) file. Store the file in your OneDrive account for use by Copilot in your tenant.
+1. Select the following link to download the [**Relecloud Acquisition Financials.xlsx**](https://go.microsoft.com/fwlink/?linkid=2347812) file. Store the file in your OneDrive account for use by Copilot in your tenant.
 
-2.  In your Microsoft Edge browser, go to the **Microsoft 365** home page, select **Apps** in the navigation pane, and then select **Excel** from the **Apps** menu.
+2. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page, select **Apps** in the navigation pane, and then select **Excel** from the **Apps** menu.
 
-3.  In **Excel for the web**, select the **Upload a file** button, navigate to your OneDrive, and then select the **Relecloud Acquisition Financials** spreadsheet that you downloaded in step 1.
+   > [!NOTE]
+   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Excel** from the list of apps that appears.
 
-4.  On the **Home** tab ribbon, select **Copilot**. In the Copilot pane, leave the response mode selector set to **Auto**. Then verify the **Edit with Copilot** icon appears in the prompt field next to the plus (+) sign. If you don’t see it, select the plus sign and then select **Edit with Copilot** in the drop-down menu. The icon should now appear in the prompt field.
+3. In **Excel for the web**, select the **Upload a file** button, navigate to your OneDrive, and then select the **Relecloud Acquisition Financials** spreadsheet that you downloaded in step 1.
 
-5.  Let’s begin by updating the Relecloud acquisition numbers based on a series of what-if scenarios. Verify you’re in the **Financial Analysis** sheet. In the Copilot prompt field, ask Copilot to perform a what-if scenario by updating the Relecloud acquisition financials to reflect a 1x increase in the earnings before interest, taxes, depreciation, and amortization (EBITDA) multiple and a 20% increase in synergy savings. Ask it to return the results in a new sheet. 
+4. In the bottom-right corner of the document, select the **Copilot** icon to open the Copilot pane. In the Copilot pane, leave the response mode selector set to **Auto**. Verify the pane opens in edit mode—the heading should read **Let's edit your workbook**, and the prompt field should display the placeholder text **Describe what you'd like to edit**. Below the heading, confirm that the mode selector is set to **Allow editing** (so Copilot can edit your workbook directly). If it shows **Chat only**, select the drop-down and then select **Allow editing**.
 
-6.  Review the results. Remain in this new what-if sheet and then ask Copilot to perform an EBITDA what-if scenario in which it generates the following charts in a new sheet to make it easy to visualize the magnitude and timing of improvements:
+5. Let’s begin by updating the Relecloud acquisition numbers based on a series of what-if scenarios. Verify you’re in the **Financial Analysis** sheet. In the Copilot prompt field, submit the following prompt:
+
+    `Using the current values in the Financial Analysis sheet as the baseline, create a what-if scenario in a new sheet for the Relecloud acquisition model. Increase each EBITDA value by 100% (treat a 1x increase as doubling the current EBITDA amount). For synergy savings, use the midpoint of each estimated annual benefit range in the Integration Planning sheet as the baseline, increase each midpoint by 20%, and show the original and updated values side by side. Include totals where appropriate and clearly label the new sheet.`
+
+6. Review the results. Remain in this new what-if sheet and then ask Copilot to perform an EBITDA what-if scenario in which it generates the following charts in a new sheet to make it easy to visualize the magnitude and timing of improvements:
 
     - Column Chart comparing original vs. updated EBITDA and total synergy savings over time.  
-        
+
     - Line Chart showing EBITDA trend before and after the change.  
 
-7.  Review the results. Select the **Financial Analysis** sheet and then ask Copilot to perform another what-if scenario in which it updates the acquisition financial model based on the following what-if scenario: Model the impact if synergy savings are delayed by 12 months and only 75% are realized. Ask Copilot to return the results in a new sheet.
+7. Review the results. Select the **Financial Analysis** sheet and then ask Copilot to perform another what-if scenario in which it updates the acquisition financial model based on the following what-if scenario: Model the impact if synergy savings are delayed by 12 months and only 75% are realized. Ask Copilot to return the results in a new sheet.
 
-8.  Review the results. Remain in this new what-if sheet and then ask Copilot to generate the following charts in a new sheet that show both the timing and reduction in benefits, highlighting the impact on cash flow and ROI:
+8. Review the results. Remain in this new what-if sheet and then ask Copilot to generate the following charts in a new sheet that show both the timing and reduction in benefits, highlighting the impact on cash flow and ROI:
 
     - Stacked Column Chart showing annual synergy savings (original vs. delayed/reduced).  
-        
+
     - Line Chart for cumulative synergy savings over time.
 
-9.  Review the results. Select the **Financial Analysis** sheet and then ask Copilot to perform a what-if scenario that updates the financial model based on operating expenses that are 10% higher due to integration challenges. Ask Copilot to return the results in a new sheet.
+9. Review the results. Select the **Financial Analysis** sheet and then ask Copilot to perform a what-if scenario that updates the financial model based on operating expenses that are 10% higher due to integration challenges. Ask Copilot to return the results in a new sheet.
 
 10. Review the results. Remain in this new what-if sheet and then ask Copilot to generate the following charts in a new sheet that highlight the effect on profitability and expense trends:
 
     - Line Chart for operating expenses and EBITDA over time (original vs. scenario).  
-        
+
     - Column Chart comparing net income before and after the change.
 
-11. Review the results. Feel free to select any of Copilot’s suggested prompts if you want to update the spreadsheet even further. 
+11. Review the results. If you want to update the spreadsheet further, select any of Copilot's suggested prompts.

--- a/Instructions/Labs/M05-empower-workforce-copilot-finance/06-Ex1-4-use-excel-model-scenarios.md
+++ b/Instructions/Labs/M05-empower-workforce-copilot-finance/06-Ex1-4-use-excel-model-scenarios.md
@@ -20,10 +20,7 @@ Perform the following steps to complete this task:
 
 1. Select the following link to download the [**Relecloud Acquisition Financials.xlsx**](https://go.microsoft.com/fwlink/?linkid=2347812) file. Store the file in your OneDrive account for use by Copilot in your tenant.
 
-2. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page, select **Apps** in the navigation pane, and then select **Excel** from the **Apps** menu.
-
-   > [!NOTE]
-   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Excel** from the list of apps that appears.
+2. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page and select the **App Launcher** (grid icon), select **More Apps**, and then select **Excel** from the list of available apps.
 
 3. In **Excel for the web**, select the **Upload a file** button, navigate to your OneDrive, and then select the **Relecloud Acquisition Financials** spreadsheet that you downloaded in step 1.
 


### PR DESCRIPTION
## Summary

This pull request updates the instructions in the Finance use case lab (Exercise 1, Task 4: Use Copilot in Excel to model What-If scenarios) to align with the latest version of Copilot in Excel. The original prompt in step 5 caused Copilot to ask multiple follow-up questions, which interrupted the attendee experience. The updated prompt is explicit and self-contained, so Copilot can produce the what-if scenario in a single turn. The pane-opening instructions have also been revised to match the current Excel for the web UI. This change addresses issue #42.

## Changes

- Updated the lab description to reflect the new what-if scenario wording that doubles each EBITDA value and increases synergy savings midpoints by 20%.

- Replaced the Microsoft 365 home page reference with Microsoft 365 Copilot, and added a note explaining how to access Excel from the App Launcher if Apps is not visible in the navigation pane.

- Reworked step 4 to open the Copilot pane from the bottom-right Copilot icon, confirm the Let's edit your workbook heading, verify the Describe what you'd like to edit placeholder, and ensure the mode selector is set to Allow editing instead of Chat only.

- Rewrote the step 5 prompt as a complete, explicit instruction that uses the Financial Analysis sheet values as the baseline, doubles each EBITDA value, uses the midpoint of each estimated annual benefit range in the Integration Planning sheet for synergy savings, increases those midpoints by 20%, shows original and updated values side by side, and includes totals on a clearly labeled new sheet, minimizing follow-up questions from Copilot.

- Minor wording cleanup in step 11 for clarity.

## Files changed

`Instructions/Labs/M05-empower-workforce-copilot-finance/06-Ex1-4-use-excel-model-scenarios.md` (19 additions, 14 deletions)

## Reply to issue #42 (Finance Use Case: Updated Prompt for Excel Example)

The latest version of Copilot in Excel asks several follow-up questions when the prompt is open-ended, which slows attendees down during the exercise. This PR addresses that by replacing the step 5 instruction with a single, explicit prompt that gives Copilot all the context it needs in one turn: it specifies the Financial Analysis sheet as the baseline, defines a 1x increase as doubling each EBITDA value, points Copilot to the midpoints of the estimated annual benefit ranges in the Integration Planning sheet for synergy savings, applies the 20% increase to those midpoints, requests original and updated values side by side with totals, and asks for the results in a clearly labeled new sheet. 

Fixes #42 