### PR TITLE
fix(lab05/ex02/t02): update PowerPoint steps to match current Copilot UI

### DIFF
--- a/Instructions/Labs/M05-empower-workforce-copilot-finance/09-Ex2-2-use-powerpoint-create-presentation.md
+++ b/Instructions/Labs/M05-empower-workforce-copilot-finance/09-Ex2-2-use-powerpoint-create-presentation.md
@@ -15,40 +15,43 @@ Your next task is to share the information that you captured in the **Smart Sens
 
 PowerPoint provides two ways to use Copilot: standard Copilot prompts for quickly generating slide content or summaries, and **Edit with Copilot** in the Copilot pane for making direct, in‑place edits to slides, layouts, and presentation structure.
 
-- You should use Copilot’s standard prompts in PowerPoint when you want to draft slides quickly, summarize content, or generate speaker notes without changing the structure of the deck. When using the Copilot pane, if you enter a prompt without selecting **Edit with Copilot**, Copilot responds in a chat‑style mode that generates suggestions or content separately, rather than making direct, in‑place changes to the presentation.  
-    
-- You should use **Edit with Copilot** when you want Copilot to work directly in the presentation—such as reorganizing slides, refining slide text, improving layouts, or making iterative edits across multiple slides. **Edit with Copilot** is optimized for in‑place presentation work, so it understands slide structure and can apply changes directly to the deck, rather than just suggesting content in a separate response.
+- You should use Copilot's standard prompts in PowerPoint when you want to draft slides quickly, summarize content, or generate speaker notes without changing the structure of the deck. When using the Copilot pane, if you enter a prompt without selecting **Edit with Copilot**, Copilot responds in a chat-style mode that generates suggestions or content separately, rather than making direct, in-place changes to the presentation.
 
-In summary, use chat‑style Copilot for thinking and generating ideas; use **Edit with Copilot** for hands‑on editing inside the file. Copilot typically previews slide or layout changes and, once you confirm, it applies those changes directly to the slide deck rather than expecting the user to explicitly apply them through copy and paste.
+- You should use **Edit with Copilot** when you want Copilot to work directly in the presentation, such as reorganizing slides, refining slide text, improving layouts, or making iterative edits across multiple slides. **Edit with Copilot** is optimized for in-place presentation work, so it understands slide structure and can apply changes directly to the deck, rather than suggesting content in a separate response.
+
+In summary, use chat-style Copilot for thinking and generating ideas; use **Edit with Copilot** for hands-on editing inside the file. Copilot typically previews slide or layout changes and, once you confirm, it applies those changes directly to the slide deck rather than expecting the user to explicitly apply them through copy and paste.
 
 This task uses the **Edit with Copilot** functionality.
 
 Perform the following steps to complete this task:
 
-1.  In your Microsoft Edge browser, go to the **Microsoft 365** home page, select **Apps** in the navigation pane, and then select **PowerPoint** from the **Apps** menu.
+1. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page, select **Apps** in the navigation pane, and then select **PowerPoint** from the **Apps** menu.
 
-2.  In **PowerPoint for the web**, create a blank presentation.
+   > [!NOTE]
+   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **PowerPoint** from the list of apps that appears.
 
-3.  Select the **Home** tab if the **Home** tab ribbon doesn’t appear. Then select **Copilot** at the end of the **Home** tab ribbon.
+2. In **PowerPoint for the web**, create a blank presentation.
 
-4.  In the Copilot pane, select the plus (+) sign in the prompt field and then select **Add work content** in the drop-down menu. Attach the **Smart Sensor contract comparison** file that you created in the prior task.
+3. Select the **Copilot** icon in the bottom-right corner of the PowerPoint window to open the Copilot pane.
 
-5.  Verify the **Edit with Copilot** icon appears next to the plus (+) sign in the prompt field. If you don’t see it, select the plus sign and then select **Edit with Copilot** in the drop-down menu. The icon should now appear in the prompt field.
+4. In the Copilot pane, select the **(+)** (plus) sign below the prompt field to open the **Add work content** file picker. Search for and select the **Smart Sensor contract comparison** file that you created in the prior task.
 
-6.  In the Copilot pane, enter in the prompt field a description of what you want Copilot to create. Remember to address the four key areas of an effective prompt. It should ask Copilot to create a slide presentation that summarizes the key findings from the attached **Smart Sensor contract comparison** file. The presentation should be targeted to the Finance leadership team. It should include a separate slide for each key finding topic area, such as Pricing, Delivery Timelines and Terms, Warranties and Support, and so on. Each slide should compare the contract features for Adatum Corporation and Contoso, Ltd. for the selected area. Tell Copilot to use visuals to keep the presentation engaging, and to use bullet points on the slides for clarity.
+5. Verify the dropdown above the prompt field is set to **Allow editing**. This ensures Copilot can make direct, in-place edits to the presentation. If you see **Chat only** selected, select the dropdown and choose **Allow editing**.
 
-7.  If Copilot asks a series of questions related to the presentation, select the answers that you want it to apply. Select the **Confirm** button once you finish answering the questions. It might also ask a second series of questions, one of which might be to select a slide template. Keep in mind that if you don’t select a template, Copilot simply presents text on plain white slides. Again, select the answers that you want it to apply, or select **Skip all** if you want Copilot to use its best judgment.
+6. In the Copilot pane, enter in the prompt field a description of what you want Copilot to create. Remember to address the four key areas of an effective prompt. It should ask Copilot to create a slide presentation that summarizes the key findings from the attached **Smart Sensor contract comparison** file. The presentation should be targeted to the Finance leadership team. It should include a separate slide for each key finding topic area, such as Pricing, Delivery Timelines and Terms, Warranties and Support, and so on. Each slide should compare the contract features for Adatum Corporation and Contoso, Ltd. for the selected area. Tell Copilot to use visuals to keep the presentation engaging, and to use bullet points on the slides for clarity.
 
-8.  Copilot in PowerPoint uses this information to generate a list of slides, which might take a few minutes.
+7. If Copilot asks a series of questions related to the presentation, select the answers that you want it to apply. Select the **Confirm** button once you finish answering the questions. It might also ask a second series of questions, one of which might be to select a slide template. Keep in mind that if you don't select a template, Copilot simply presents text on plain white slides. Again, select the answers that you want it to apply, or select **Skip all** if you want Copilot to use its best judgment.
 
-9.  During our testing, we experienced different results with regards to slide generation. Copilot sometimes generated the slides automatically, with no further confirmation needed. Other times, it provided an outline of the slides in the Copilot chat pane, and it suggested several options as to how it could proceed. If you experience the latter scenario, tell it to proceed with the outline. In either case, it typically took several minutes for Copilot to generate the slides.
+8. Copilot in PowerPoint uses this information to generate a list of slides. Wait for the slides to generate, which might take a few minutes.
 
-10. Review the slides that Copilot generated. While you feel that you have a solid foundation for the Finance leadership presentation, you notice a few changes that you would like to make. First off, you’re confident that leadership is going to ask about risk mitigation, which isn’t mentioned in the presentation. Before requesting a new slide, you must first indicate where you want the slide to appear in the deck. Review the slides and find a location where this topic would fit. Then in the slide pane on the left, select where you want Copilot to insert the slide. Now that you’ve selected the location, enter a prompt that asks Copilot to add a slide that contains the top recommendations for mitigating risks. The slide should also include a visual emphasis, such as callouts or highlights, for critical points.
+9. During our testing, we experienced different results with regard to slide generation. Copilot sometimes generated the slides automatically, with no further confirmation needed. Other times, it provided an outline of the slides in the Copilot chat pane, and it suggested several options as to how it could proceed. If you experience the latter scenario, tell it to proceed with the outline. In either case, it typically took several minutes for Copilot to generate the slides.
+
+10. Review the slides that Copilot generated. While you feel that you have a solid foundation for the Finance leadership presentation, you notice a few changes that you would like to make. You're confident that leadership is going to ask about risk mitigation, which isn't mentioned in the presentation. Before requesting a new slide, you must first indicate where you want the slide to appear in the deck. Review the slides and find a location where this topic would fit. Then in the slide pane on the left, select where you want Copilot to insert the slide. Now that you've selected the location, enter a prompt that asks Copilot to add a slide that contains the top recommendations for mitigating risks. The slide should also include a visual emphasis, such as callouts or highlights, for critical points.
 
 11. Copilot might once again ask you a series of questions related to this new slide. In fact, it might ask you to select the template to use, even though you specified a template during the initial slide generation. It might take several minutes for Copilot to generate the slide.
 
 12. Once again in our testing, we saw that Copilot might add the slide automatically to the slide deck, with no further confirmation needed. Other times, it provided an outline of the slide in the Copilot chat pane, and it suggested several options as to how it could proceed. If you experience the latter scenario, tell it to add the planned slide to the presentation. In either case, it typically took several minutes for Copilot to generate the slide.
-    
+
 13. You now want Copilot to add a Vendor Advantage Summary slide. You want this slide added to the end of the deck, so locate your cursor in the deck accordingly. Then ask Copilot to add a Vendor Advantage Summary slide that indicates which vendor offers better points for each topic covered in the presentation.
 
 14. Review the slide that Copilot generated at the end of the deck. Finally, you want Copilot to create an action plan slide. You want this to be the final slide in the deck, so select in the slide deck after the final slide. Then ask Copilot to add an Action Plan slide that identifies the next steps for negotiations and risk mitigation. The slide should include a timeline and responsible roles.

--- a/Instructions/Labs/M05-empower-workforce-copilot-finance/09-Ex2-2-use-powerpoint-create-presentation.md
+++ b/Instructions/Labs/M05-empower-workforce-copilot-finance/09-Ex2-2-use-powerpoint-create-presentation.md
@@ -25,10 +25,7 @@ This task uses the **Edit with Copilot** functionality.
 
 Perform the following steps to complete this task:
 
-1. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page, select **Apps** in the navigation pane, and then select **PowerPoint** from the **Apps** menu.
-
-   > [!NOTE]
-   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **PowerPoint** from the list of apps that appears.
+1. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page and select the **App Launcher** (grid icon), select **More Apps**, and then select **PowerPoint** from the list of available apps.
 
 2. In **PowerPoint for the web**, create a blank presentation.
 


### PR DESCRIPTION
## Summary

Updates Exercise 2, Task 2 (Use Copilot in PowerPoint to create an executive presentation) in Module 5 (Finance) to match the current PowerPoint for the web Copilot UI. The Copilot entry point, file attachment flow, and editing mode toggle have all changed since the original instructions were written.

## Changes

- Updated step 1 to reference **Microsoft 365 Copilot** home page and rewroted the initial step to use **App Launcher**
- Updated step 3: Copilot is now accessed via the Copilot icon in the bottom-right corner, not from the Home tab ribbon
- Updated step 4: the **+** sign is below the prompt field and opens the **Add work content** file picker directly
- Updated step 5: replaced **Edit with Copilot** icon reference with the **Allow editing** dropdown
- Updated step 8: converted informational statement to actionable instruction
- Fixed heading level from `####` to `###` to correct skipped heading hierarchy
- Replaced non-breaking hyphens with standard hyphens throughout
- Minor grammar fixes ('with regards to' to 'with regard to', removed 'First off' filler)
- Changed file name in step 16 from bold to backticks (typed value, not UI element)

## Files changed

- `Instructions/Labs/M05-empower-workforce-copilot-finance/09-Ex2-2-use-powerpoint-create-presentation.md` — updated Copilot UI navigation steps, fixed heading hierarchy, standardized hyphens, and applied style corrections