### PR TITLE
fix(lab05/ex02/t03): update Loop steps to match current Copilot UI

### DIFF
--- a/Instructions/Labs/M05-empower-workforce-copilot-finance/10-Ex2-3-use-loop-turn-insights-into-actions.md
+++ b/Instructions/Labs/M05-empower-workforce-copilot-finance/10-Ex2-3-use-loop-turn-insights-into-actions.md
@@ -13,10 +13,7 @@ Before presenting the PowerPoint presentation titled **Smart Sensor contract com
 
 Perform the following steps to complete this task:
 
-1. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page, select **Apps** in the navigation pane, and then select **Loop** from the **Apps** menu.
-
-   > [!NOTE]
-   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Loop** from the list of apps that appears.
+1. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page and select the **App Launcher** (grid icon), select **More Apps**, and then select **Loop** from the list of available apps.
 
 2. In **Loop for the web**, select the **+** (create new) icon on the left navigation pane, and then select **New workspace**.
 

--- a/Instructions/Labs/M05-empower-workforce-copilot-finance/10-Ex2-3-use-loop-turn-insights-into-actions.md
+++ b/Instructions/Labs/M05-empower-workforce-copilot-finance/10-Ex2-3-use-loop-turn-insights-into-actions.md
@@ -42,4 +42,4 @@ Perform the following steps to complete this task:
 
 13. Review the results and then copy and paste the content into your Loop page. Delete any extraneous text that was copied and pasted along with the communication plan.
 
-14. In the next task, you will create an email for your Finance colleagues that includes a link to the Loop workspace that you created. Keep the Loop workspace open so that you can copy its link.
+14. In the next task, you create an email for your Finance colleagues that includes a link to the Loop workspace that you created. To copy the workspace link, select the **Share** dropdown at the top of the page, select **Workspace**, and then select **Copy Link**. Keep the Loop workspace open for now.

--- a/Instructions/Labs/M05-empower-workforce-copilot-finance/10-Ex2-3-use-loop-turn-insights-into-actions.md
+++ b/Instructions/Labs/M05-empower-workforce-copilot-finance/10-Ex2-3-use-loop-turn-insights-into-actions.md
@@ -13,29 +13,33 @@ Before presenting the PowerPoint presentation titled **Smart Sensor contract com
 
 Perform the following steps to complete this task:
 
-1.  In your Microsoft Edge browser, go to the **Microsoft 365** home page, select **Apps** in the navigation pane, and then select **Loop** from the **Apps** menu.
+1. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page, select **Apps** in the navigation pane, and then select **Loop** from the **Apps** menu.
 
-2.  In **Loop for the web**, create a new workspace titled **Adatum/Contoso contract comparison**.
+   > [!NOTE]
+   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Loop** from the list of apps that appears.
 
-3.  You plan to create three new pages under this Loop workspace – one for negotiation strategy, another for risk mitigation ideas, and a third for communication framing. To begin, change the current title of the first page from **Untitled** to **Negotiation Strategy**.
+2. In **Loop for the web**, select the **+** (create new) icon on the left navigation pane, and then select **New workspace**.
 
-4.  Open the Copilot pane.
+3. In the **Create a new workspace** dialog, enter `Adatum/Contoso contract comparison` in the name field, and then select **Create**.
 
-5.  Ask Copilot to review the attached **Smart Sensor contract comparison – Finance.pptx** file and turn its negotiation recommendations into a structured Loop table with columns like Action, Priority, Owner, and Deadline. Attach the file by entering a forward slash and then selecting the **Smart Sensor contract comparison – Finance.pptx** file from the **Files** tab.
+4. You plan to create three new pages under this Loop workspace – one for negotiation strategy, another for risk mitigation ideas, and a third for communication framing. To begin, change the current title of the first page from **Untitled** to **Negotiation Strategy**.
 
-6.  Review the table results and then select the **Copy** icon that appears below the table. Paste the copied results into your Loop page. Delete any extraneous text that was copied and pasted along with the table.
+5. Select the **Copilot** icon at the top of the page to open the Copilot pane.
 
-7.  Next, add a new page under your **Adatum/Contoso contract comparison** workspace. Change the title of the page from **Untitled** to **Risk mitigation ideas**.
+6. Ask Copilot to review the attached **Smart Sensor contract comparison - Finance.pptx** file and turn its negotiation recommendations into a structured Loop table with columns like Action, Priority, Owner, and Deadline. Attach the file by entering a forward slash and then selecting the **Smart Sensor contract comparison - Finance.pptx** file from the **Files** tab.
 
-8.  Open the Copilot pane and ask Copilot to review the attached **Smart Sensor contract comparison – Finance.pptx** file and turn the risk mitigation ideas into a checklist with status fields for tracking.
+7. Review the table results and then select the **Copy** icon that appears below the table. Paste the copied results into your Loop page. Delete any extraneous text that was copied and pasted along with the table.
 
-9.  Review the results and then copy and paste the content into your Loop page. Delete any extraneous text that was copied and pasted along with the ideas.
+8. In the left navigation pane, select **Create new page** to add a new page under your **Adatum/Contoso contract comparison** workspace. Change the title of the page from **Untitled** to **Risk mitigation ideas**.
 
-10. Finally, add a new page under your **Adatum/Contoso contract comparison** workspace. Change the title of the page from **Untitled** to **Communication plan**.
+9. Select the **Copilot** icon at the top of the page to open the Copilot pane, and then ask Copilot to review the attached **Smart Sensor contract comparison - Finance.pptx** file and turn the risk mitigation ideas into a checklist with status fields for tracking.
 
-11. Open the Copilot pane and ask Copilot to review the attached **Smart Sensor contract comparison – Finance.pptx** file and draft a communication plan for sharing its recommendations with stakeholders, including timeline and channels.
+10. Review the results and then copy and paste the content into your Loop page. Delete any extraneous text that was copied and pasted along with the ideas.
 
-12. Review the results and then copy and paste the content into your Loop page. Delete any extraneous text that was copied and pasted along with the communication plan.
+11. Finally, add a new page under your **Adatum/Contoso contract comparison** workspace. Change the title of the page from **Untitled** to **Communication plan**.
 
+12. Open the Copilot pane and ask Copilot to review the attached **Smart Sensor contract comparison – Finance.pptx** file and draft a communication plan for sharing its recommendations with stakeholders, including timeline and channels.
 
-13. In the next task, you create an email for your Finance colleagues that includes a link to the Loop workspace that you just created. Keep the Loop workspace open so that you can copy its link.
+13. Review the results and then copy and paste the content into your Loop page. Delete any extraneous text that was copied and pasted along with the communication plan.
+
+14. In the next task, you will create an email for your Finance colleagues that includes a link to the Loop workspace that you created. Keep the Loop workspace open so that you can copy its link.


### PR DESCRIPTION
## Summary

Updates Exercise 2, Task 3 (Use Copilot in Loop to turn insights into actionable content) in Module 5 (Finance) to match the current Loop for the web UI. The workspace creation flow, Copilot entry point, and page creation path have changed since the original instructions were written.

## Changes

- Updated step 1 to reference **Microsoft 365 Copilot** home page and changed the step to use App Launcher navigation
- Updated step 2: replaced vague 'create a new workspace' with explicit UI path (select **+** icon → **New workspace**)
- Added step 3: **Create a new workspace** dialog with name field and **Create** button
- Updated steps 5 and 9: 'Open the Copilot pane' → 'Select the **Copilot** icon at the top of the page'
- Updated step 8: 'add a new page' → 'select **Create new page**' in the left navigation pane
- Replaced en dashes with standard hyphens in file names throughout
- Renumbered steps 3–13 → 4–14 to accommodate the new workspace creation step
- Fixed YAML front matter line endings
- Fixed future tense in step 14; added explicit instructions to copy the Loop workspace link via Share > Workspace > Copy Link to match current UI.

## Files changed

- `Instructions/Labs/M05-empower-workforce-copilot-finance/10-Ex2-3-use-loop-turn-insights-into-actions.md` — updated Loop UI navigation steps, added workspace creation dialog step, standardized Copilot icon references, and fixed hyphens