### PR TITLE
Fix/Lab M05-empower-workforce-copilot-finance/11-Ex2-4-use-outlook-create-email.md. Update Outlook email task steps and refine workflow documentation

### DIFF
--- a/Instructions/Labs/M05-empower-workforce-copilot-finance/11-Ex2-4-use-outlook-create-email.md
+++ b/Instructions/Labs/M05-empower-workforce-copilot-finance/11-Ex2-4-use-outlook-create-email.md
@@ -26,21 +26,28 @@ Perform the following steps to complete this task:
 
 4. In the Copilot prompt field that appears, enter a prompt that asks Copilot to write a short, direct email to your colleagues on the Finance team requesting feedback on your draft contract comparison presentation. In your prompt, paste the Loop workspace URL that you copied in the prior task and ask Copilot to include it for collaboration purposes. Use a professional, formal tone and convey urgency.
 
-5. Review the results. Upon review, you decide that maybe a different approach would be best. You decide to use Copilot to modify the email to make it more conversational and friendly in tone. In the Copilot window that appears below the message, ask Copilot to start the email by highlighting the benefits of using the Loop component for real-time collaboration. Then ask it to explain in greater detail why feedback is important, and have it outline the next steps.
+   > [!TIP]
+   > If you no longer have the workspace URL, go back to Loop, select
+   > the **Adatum/Contoso contract comparison** workspace that you created in the prior task, select the **Share** button in the top right corner of the workspace, select **Copy link**, and then paste the link into your prompt in Outlook.
 
-6. Review the updated email. Notice how Copilot generated a new version of the email, which is draft 2 (2 of 2). You can select the back arrow to go to draft 1 of 2, which was the original version of the email that Copilot generated. Since you prefer to keep working with the latest draft, select the forward arrow to return to draft 2 of 2.
+5. Review the results. Upon review, you decide that maybe a different approach would be best. You decide to use Copilot to modify the email to make it more conversational and friendly in tone. In the Copilot pane that appears below the message, ask Copilot to start the email by highlighting the benefits of using the Loop component for real-time collaboration. Then ask it to explain in greater detail why feedback is important, and have it outline the next steps.
+
+6. Review the updated email. Notice how Copilot generated a new version of the email, which is draft 2 (2 of 2). At the bottom of the draft, you can select the back arrow to go to draft 1 of 2, which was the original version of the email that Copilot generated. Since you prefer to keep working with the latest draft, select the forward arrow to return to draft 2 of 2.
 
    > [!NOTE]
    > For each request that you make, Copilot generates a new draft of the email. You can optionally navigate to a prior draft and keep it, or you can ask Copilot to modify that draft (rather than the last draft). By default, you typically make each new request while viewing the last draft.
 
 7. While you like the content of draft 2, you feel that a different structure might be better. Ask Copilot to rewrite the email and list the key points for review in bullet format. Start the email by stressing the deadline for feedback.
 
-8. Review the results (which is now draft 3 of 3). While the email looks better, you decide that you need one final paragraph. Ask Copilot to add a single paragraph at the end of the email that explains how your colleagues’ input should improve the final deliverable. Include a motivating phrase like ‘Your insights will make a big impact.’
+8. Review the results (which is now draft 3 of 3). While the email looks better, you decide that you need one final paragraph. Ask Copilot to add a single paragraph at the end of the email that explains how your colleagues' input should improve the final deliverable. Include a motivating phrase like 'Your insights will make a big impact.'
 
-9. Review the results. After re-reading the email, you aren’t sure about the tone of the message. In the Copilot menu, scroll down and select **Change Tone** and then select one of the tones from the menu.
+9. Review the results. After rereading the email, you aren't sure about the tone of the message. Select **Replace** at the bottom of the draft. In the menu that appears, select the **Open Copilot** icon, select **Change Tone**, and then select one of the tones from the submenu.
+
+   > [!NOTE]
+   > When Copilot changes the tone, it may convert the Loop workspace hyperlink to plain text. After you finalize the draft, verify that the link is still active. If it appears as plain text, select the URL text, and then use the **Insert hyperlink** option on the toolbar to restore it, or select the URL text and paste the URL into the email again to make it an active hyperlink.
 
 10. Review the new draft that Copilot generated. You still aren’t satisfied with the way the email sounds, so this time ask Copilot to change the tone by making it sound friendly and confident but still professional.
 
-11. Review the results. You’re satisfied with this version, so select the **Keep it** option in the Copilot window. Doing so takes you out of Copilot draft mode and into the actual email itself. 
+11. Review the results. You're satisfied with this version, so select **Replace** at the Copilot window. Doing so takes you out of Copilot draft mode and into the actual email itself.
 
 12. Feel free to send the email to your personal email address. Verify that you received it and that the link to the Loop component works.

--- a/Instructions/Labs/M05-empower-workforce-copilot-finance/11-Ex2-4-use-outlook-create-email.md
+++ b/Instructions/Labs/M05-empower-workforce-copilot-finance/11-Ex2-4-use-outlook-create-email.md
@@ -24,25 +24,14 @@ Perform the following steps to complete this task:
 
 3. Use **Copilot in Outlook** to draft the email message. In the body of the message, select the **Open Copilot** icon.
 
-4. In the Copilot prompt field that appears, enter a prompt that asks
-   Copilot to write a short, direct email to your colleagues on the
-   Finance team requesting feedback on your draft contract comparison
-   presentation. In your prompt, paste the Loop workspace URL that you
-   copied in the prior task and ask Copilot to include it for
-   collaboration purposes. Use a professional, formal tone and convey
-   urgency.
-
-   > [!TIP]
-   > If you no longer have the workspace URL, go back to Loop, select
-   > the **Adatum/Contoso contract comparison** workspace in the left
-   > navigation pane, and copy the URL from the browser address bar.
+4. In the Copilot prompt field that appears, enter a prompt that asks Copilot to write a short, direct email to your colleagues on the Finance team requesting feedback on your draft contract comparison presentation. In your prompt, paste the Loop workspace URL that you copied in the prior task and ask Copilot to include it for collaboration purposes. Use a professional, formal tone and convey urgency.
 
 5. Review the results. Upon review, you decide that maybe a different approach would be best. You decide to use Copilot to modify the email to make it more conversational and friendly in tone. In the Copilot window that appears below the message, ask Copilot to start the email by highlighting the benefits of using the Loop component for real-time collaboration. Then ask it to explain in greater detail why feedback is important, and have it outline the next steps.
 
 6. Review the updated email. Notice how Copilot generated a new version of the email, which is draft 2 (2 of 2). You can select the back arrow to go to draft 1 of 2, which was the original version of the email that Copilot generated. Since you prefer to keep working with the latest draft, select the forward arrow to return to draft 2 of 2. 
 
    > [!NOTE]
-   > For each request that you make, Copilot generates a new draft of the email. You can optionally navigate to a prior draft and keep it, or you can ask Copilot to modify that draft (rather than the last draft). By default, you typically make each new request while viewing the last draft. 
+   > For each request that you make, Copilot generates a new draft of the email. You can optionally navigate to a prior draft and keep it, or you can ask Copilot to modify that draft (rather than the last draft). By default, you typically make each new request while viewing the last draft.
 
 7. While you like the content of draft 2, you feel that a different structure might be better. Ask Copilot to rewrite the email and list the key points for review in bullet format. Start the email by stressing the deadline for feedback.
 

--- a/Instructions/Labs/M05-empower-workforce-copilot-finance/11-Ex2-4-use-outlook-create-email.md
+++ b/Instructions/Labs/M05-empower-workforce-copilot-finance/11-Ex2-4-use-outlook-create-email.md
@@ -15,10 +15,7 @@ This exercise helps you become familiar with Copilot’s draft process in Outloo
 
 Perform the following steps to complete this task:
 
-1. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page, select **Apps** in the navigation pane, and then select **Outlook** from the **Apps** menu.
-
-   > [!NOTE]
-   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Outlook** from the list of apps that appears.
+1. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page and select the **App Launcher** (grid icon), select **More Apps**, and then select **Outlook** from the list of available apps.
 
 2. In **Outlook on the web**, create a new email.
 

--- a/Instructions/Labs/M05-empower-workforce-copilot-finance/11-Ex2-4-use-outlook-create-email.md
+++ b/Instructions/Labs/M05-empower-workforce-copilot-finance/11-Ex2-4-use-outlook-create-email.md
@@ -28,7 +28,7 @@ Perform the following steps to complete this task:
 
 5. Review the results. Upon review, you decide that maybe a different approach would be best. You decide to use Copilot to modify the email to make it more conversational and friendly in tone. In the Copilot window that appears below the message, ask Copilot to start the email by highlighting the benefits of using the Loop component for real-time collaboration. Then ask it to explain in greater detail why feedback is important, and have it outline the next steps.
 
-6. Review the updated email. Notice how Copilot generated a new version of the email, which is draft 2 (2 of 2). You can select the back arrow to go to draft 1 of 2, which was the original version of the email that Copilot generated. Since you prefer to keep working with the latest draft, select the forward arrow to return to draft 2 of 2. 
+6. Review the updated email. Notice how Copilot generated a new version of the email, which is draft 2 (2 of 2). You can select the back arrow to go to draft 1 of 2, which was the original version of the email that Copilot generated. Since you prefer to keep working with the latest draft, select the forward arrow to return to draft 2 of 2.
 
    > [!NOTE]
    > For each request that you make, Copilot generates a new draft of the email. You can optionally navigate to a prior draft and keep it, or you can ask Copilot to modify that draft (rather than the last draft). By default, you typically make each new request while viewing the last draft.

--- a/Instructions/Labs/M05-empower-workforce-copilot-finance/11-Ex2-4-use-outlook-create-email.md
+++ b/Instructions/Labs/M05-empower-workforce-copilot-finance/11-Ex2-4-use-outlook-create-email.md
@@ -15,30 +15,43 @@ This exercise helps you become familiar with Copilot’s draft process in Outloo
 
 Perform the following steps to complete this task:
 
-1.  In your Microsoft Edge browser, go to the **Microsoft 365** home page, select **Apps** in the navigation pane, and then select **Outlook** from the **Apps** menu.
+1. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page, select **Apps** in the navigation pane, and then select **Outlook** from the **Apps** menu.
 
-2.  In **Outlook on the web**, create a new email.
+   > [!NOTE]
+   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Outlook** from the list of apps that appears.
 
-3.  Use **Copilot in Outlook** to draft the email message. In the body of the message, select the **Open Copilot** icon.
+2. In **Outlook on the web**, create a new email.
 
-4.  The Copilot window that appears contains a prompt field and a menu of edit options below it. In the prompt field, ask Copilot to write a short, direct email to your colleagues on the Finance team requesting feedback on your draft contract comparison presentation. In your Copilot prompt, copy and paste in the link to the Loop workspace. Ask Copilot to include this link for collaboration purposes with your Finance colleagues. Use a professional, formal tone and convey urgency.
+3. Use **Copilot in Outlook** to draft the email message. In the body of the message, select the **Open Copilot** icon.
 
-5.  Review the results. Upon review, you decide that maybe a different approach would be best. You decide to use Copilot to modify the email to make it more conversational and friendly in tone. In the Copilot window that appears below the message, ask Copilot to start the email by highlighting the benefits of using the Loop component for real-time collaboration. Then ask it to explain in greater detail why feedback is important, and have it outline the next steps.
+4. In the Copilot prompt field that appears, enter a prompt that asks
+   Copilot to write a short, direct email to your colleagues on the
+   Finance team requesting feedback on your draft contract comparison
+   presentation. In your prompt, paste the Loop workspace URL that you
+   copied in the prior task and ask Copilot to include it for
+   collaboration purposes. Use a professional, formal tone and convey
+   urgency.
 
-6.  Review the updated email. Notice how Copilot generated a new version of the email, which is draft 2 (2 of 2). You can select the back arrow to go to draft 1 of 2, which was the original version of the email that Copilot generated. Since you prefer to keep working with the latest draft, select the forward arrow to return to draft 2 of 2. 
+   > [!TIP]
+   > If you no longer have the workspace URL, go back to Loop, select
+   > the **Adatum/Contoso contract comparison** workspace in the left
+   > navigation pane, and copy the URL from the browser address bar.
+
+5. Review the results. Upon review, you decide that maybe a different approach would be best. You decide to use Copilot to modify the email to make it more conversational and friendly in tone. In the Copilot window that appears below the message, ask Copilot to start the email by highlighting the benefits of using the Loop component for real-time collaboration. Then ask it to explain in greater detail why feedback is important, and have it outline the next steps.
+
+6. Review the updated email. Notice how Copilot generated a new version of the email, which is draft 2 (2 of 2). You can select the back arrow to go to draft 1 of 2, which was the original version of the email that Copilot generated. Since you prefer to keep working with the latest draft, select the forward arrow to return to draft 2 of 2. 
 
    > [!NOTE]
    > For each request that you make, Copilot generates a new draft of the email. You can optionally navigate to a prior draft and keep it, or you can ask Copilot to modify that draft (rather than the last draft). By default, you typically make each new request while viewing the last draft. 
 
 7. While you like the content of draft 2, you feel that a different structure might be better. Ask Copilot to rewrite the email and list the key points for review in bullet format. Start the email by stressing the deadline for feedback.
 
-8.  Review the results (which is now draft 3 of 3). While the email looks better, you decide that you need one final paragraph. Ask Copilot to add a single paragraph at the end of the email that explains how your colleagues’ input should improve the final deliverable. Include a motivating phrase like ‘Your insights will make a big impact.’
+8. Review the results (which is now draft 3 of 3). While the email looks better, you decide that you need one final paragraph. Ask Copilot to add a single paragraph at the end of the email that explains how your colleagues’ input should improve the final deliverable. Include a motivating phrase like ‘Your insights will make a big impact.’
 
-9.  Review the results. After re-reading the email, you aren’t sure about the tone of the message. In the Copilot menu, scroll down and select **Change Tone** and then select one of the tones from the menu.
+9. Review the results. After re-reading the email, you aren’t sure about the tone of the message. In the Copilot menu, scroll down and select **Change Tone** and then select one of the tones from the menu.
 
-10.  Review the new draft that Copilot generated. You still aren’t satisfied with the way the email sounds, so this time ask Copilot to change the tone by making it sound friendly and confident but still professional.
+10. Review the new draft that Copilot generated. You still aren’t satisfied with the way the email sounds, so this time ask Copilot to change the tone by making it sound friendly and confident but still professional.
 
 11. Review the results. You’re satisfied with this version, so select the **Keep it** option in the Copilot window. Doing so takes you out of Copilot draft mode and into the actual email itself. 
 
-12.  Feel free to send the email to your personal email address. Verify that you received it and that the link to the Loop component works.
-
+12. Feel free to send the email to your personal email address. Verify that you received it and that the link to the Loop component works.


### PR DESCRIPTION
## Summary

This PR updates the instructions for Lab M05, Exercise 2, Task 4 ("Use Copilot in Outlook to create an email that requests feedback") to clarify navigation steps, improve formatting consistency, and address user confusion around linking to a Loop workspace.

## Changes

- Clarified step 1 to reference "Microsoft 365 Copilot" home page and rewrited the step for finding Outlook via the App Launcher 
- Updated step 4 to explicitly instruct users to paste the Loop workspace URL copied from the prior task, removing ambiguous "copy and paste in the link" language.
- Added a TIP callout with instructions on how to retrieve the Loop workspace link if it was not previously copied (via Share > Copy link).
- Added a NOTE about Copilot potentially converting hyperlinks to plain text when changing tone, with guidance on how to restore the link.
- Updated step 9 to reflect the current Copilot UI flow (Replace > Open Copilot > Change Tone).
- Updated step 11 to reflect the current "Replace" button behavior instead of the outdated "Keep it" option.
- Fixed line ending inconsistencies (LF to CRLF) and minor formatting adjustments (trailing spaces, numbering alignment).

## Files changed
 `Instructions/Labs/M05-empower-workforce-copilot-finance/11-Ex2-4-use-outlook-create-email.md`
 
## Reply to Issue #43 (Linking to Loop Workspace)

Fixes #43
This PR addresses the concern raised in #43. The updated instructions now clarify that users should:

1. Go to the Loop workspace created in the prior task.
2. Select the **Share** button in the top right corner of the workspace.
3. Select **Copy link** to obtain the workspace URL.
4. Paste that URL directly into the Copilot prompt in Outlook.

The previous wording ("copy and paste in the link to the Loop workspace") was ambiguous and did not explain how to obtain the link. The revised step 4 and the new TIP callout provide explicit guidance on retrieving and using the workspace URL, which should resolve the confusion attendees experienced.

Additionally, as per [PR #66](https://github.com/MicrosoftLearning/MS-4004-Empower-workforce-copilot-use-cases/pull/66), step 14 in `Instructions/Labs/M05-empower-workforce-copilot-finance/10-Ex2-3-use-loop-turn-insights-into-actions.md` was also replaced with updated instructions that now explicitly guide users on how to copy the Loop workspace link:

> 14. In the next task, you create an email for your Finance colleagues that includes a link to the Loop workspace that you created. To copy the workspace link, select the **Share** dropdown at the top of the page, select **Workspace**, and then select **Copy Link**. Keep the Loop workspace open for now.

This ensures the workflow between Task 3 and Task 4 is consistent, and users have clear instructions on obtaining the workspace URL before moving to the Outlook email task.