### PR TITLE
Update folder(m03-empower-workforce-copilot-it): update IT module labs for UI drift and Microsoft Learn style

### DIFF
--- a/Instructions/Labs/M03-empower-workforce-copilot-it/01-introduction.md
+++ b/Instructions/Labs/M03-empower-workforce-copilot-it/01-introduction.md
@@ -14,29 +14,44 @@ lab:
 
 In this module, we'll create prompts for Microsoft 365 Copilot that reference files. First, let’s upload all required files to OneDrive to ensure they're accessible throughout the lab.
 
-
 ### Uploading Files to OneDrive
 
-Follow the steps below to upload all files needed to **OneDrive**:
+Follow the steps below to upload all required files to **OneDrive**:
 
-1. Log into the virtual machine provided by your tenant provider as the local **Administrator** account with the password `Pa55w.rd`.
+1. Log in to the virtual machine provided by your tenant provider as the local **Administrator** account with the password `Pa55w.rd`.
+
 2. In the Windows taskbar, select **Microsoft Edge**.
+
 3. In the address bar, enter `https://www.office.com`.
-4. Under **Welcome to Microsoft 365**, select **Sign in**.
-5. At the **Sign-in prompt**, enter `userx@yourtenant.onmicrosoft.com` (username and tenant provided by your tenant provided) and select **Next**.
-6. At the **Enter password** screen, enter the password (provided by tenant provider) for the User account, then select **Sign in**.
+
+4. On the **Microsoft 365 Copilot** landing page, select **Sign in**.
+
+5. At the **Sign-in prompt**, enter `userx@yourtenant.onmicrosoft.com` (username and tenant provided by your tenant provider) and select **Next**.
+
+6. At the **Enter password** screen, enter the password (provided by your tenant provider) for the User account, then select **Sign in**.
+
 7. If prompted to **Stay signed in**, select **Don't show this again** and then **Yes**.
-8. In **Microsoft 365**, select **Apps**.
+
+8. In **Microsoft 365 Copilot**, select **Apps**.
+
+   > [!NOTE]
+   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **OneDrive** from the list of apps that appears.
+
 9. Within **Apps**, select **OneDrive**.
-10. In **OneDrive**, in the top-left corner, select **+** (add new) > **File upload**.
+
+10. In **OneDrive**, in the top-left corner, select **+ Create or upload** > **Files upload**.
+
 11. In **File Explorer**, select **This PC** > **Local Disk (C:)** and open the **ResourceFiles** folder.
+
 12. Select all files within the **ResourceFiles** folder, then select **Open** to upload them to **OneDrive**.
-13. When the upload is complete, you should see **Uploaded 29 items to My files** in the bottom center of the screen.
+
+13. When the upload is complete, you should see **Uploaded 92 items to My files** in the bottom center of the screen.
+
 14. Leave **Edge** open and move on to the next task.
 
 ### Referencing Files in Copilot
 
-When using Copilot, you may find that some files aren’t immediately available in the suggestions. This occurs because certain Copilot experiences only reference files from the **Most Recently Used (MRU)** list, while others let you browse **OneDrive** directly. To ensure a file appears in the **MRU** list, simply open it in the relevant Microsoft 365 app, and it will be added automatically.
+When using Copilot, you may find that some files aren't immediately available in the suggestions. This occurs because certain Copilot experiences only reference files from the **Most Recently Used (MRU)** list, while others let you browse **OneDrive** directly. To ensure a file appears in the **MRU** list, simply open it in the relevant Microsoft 365 app, and it will be added automatically.
 
 > [!IMPORTANT]
 > Microsoft 365 Copilot can only work with files saved to **OneDrive**. Files stored locally on your PC will need to be moved to **OneDrive** for Copilot to access them.
@@ -79,4 +94,3 @@ One of the primary keys to effectively using Copilot is the quality of your Copi
 - **Expectations**. Define how you want the response delivered—tone, style, or level of detail. For example: “Use simple language so I can get up to speed quickly” or “Explain it as if I were a pirate.”
 
 Keep these four elements front and center as you practice creating prompts—they’re the foundation for getting clear, accurate, and useful results from Copilot. Implementing these elements as you write prompts in these exercises can build real-world skills, so writing effective prompts becomes second nature.
-

--- a/Instructions/Labs/M03-empower-workforce-copilot-it/01-introduction.md
+++ b/Instructions/Labs/M03-empower-workforce-copilot-it/01-introduction.md
@@ -32,10 +32,7 @@ Follow the steps below to upload all required files to **OneDrive**:
 
 7. If prompted to **Stay signed in**, select **Don't show this again** and then **Yes**.
 
-8. In **Microsoft 365 Copilot**, select **Apps**.
-
-   > [!NOTE]
-   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **OneDrive** from the list of apps that appears.
+8. In **Microsoft 365 Copilot**, select the **App Launcher** (grid icon), and then select **More Apps**.
 
 9. Within **Apps**, select **OneDrive**.
 

--- a/Instructions/Labs/M03-empower-workforce-copilot-it/02-Ex1-introduction-project-planning-exercise.md
+++ b/Instructions/Labs/M03-empower-workforce-copilot-it/02-Ex1-introduction-project-planning-exercise.md
@@ -14,14 +14,14 @@ lab:
 ---
 Modern IT departments face a rapidly evolving landscape, where the demand for speed, efficiency, and innovation is higher than ever. Whether deploying new infrastructure, upgrading applications, or supporting hybrid work environments, IT teams must juggle multiple priorities—often with limited resources and tight deadlines. The complexity of these projects requires not only technical expertise but also seamless coordination, clear communication, and robust documentation.
 
-Throughout this exercise, you discover how integrating Copilot into your daily workflows can revolutionize project planning and execution. Copilot enables IT teams to collaborate more effectively, brainstorm solutions, and keep project content up to date—all while reducing administrative overhead and lowering overall project management costs. By utilizing Copilot’s tools, IT professionals can not only meet the demands of today’s fast-paced environment but also position their organizations for future growth and resilience.
+Throughout this exercise, you discover how integrating Copilot into your daily workflows can revolutionize project planning and execution. Copilot enables IT teams to collaborate more effectively, brainstorm solutions, and keep project content up to date—all while reducing administrative overhead and lowering overall project management costs. By utilizing Copilot's tools, IT professionals can not only meet the demands of today's fast-paced environment but also position their organizations for future growth and resilience.
 
 > [!TIP]
 > The Introduction unit in this module reminded you of the four key elements of an effective prompt: Goal, Context, Sources, and Expectations. Keep these elements in mind as you create prompts in this exercise.
 
 ### Scenario
 
-As the Director of IT at Boulder Innovations, you're leading a critical initiative aimed at transforming the company’s digital infrastructure. The current network has reached its limits in supporting the demands of hybrid work, secure data access, and high-performance collaboration. Your goal is to design and implement a modern, resilient, and secure network that enhances productivity while minimizing downtime and risk.
+As the Director of IT at Boulder Innovations, you're leading a critical initiative aimed at transforming the company's digital infrastructure. The current network has reached its limits in supporting the demands of hybrid work, secure data access, and high-performance collaboration. Your goal is to design and implement a modern, resilient, and secure network that enhances productivity while minimizing downtime and risk.
 
 This initiative includes replacing outdated hardware, implementing zero-trust security protocols, and ensuring business continuity during the transition. The CIO expects your team to demonstrate not only technical excellence but also operational transparency and sound project governance. You plan to use Microsoft 365 Copilot as your digital partner throughout the process, helping your team work smarter, not harder, as you move from planning to reporting.
 
@@ -31,6 +31,6 @@ Over the course of this exercise, you plan to use the following Copilot features
 
 - Copilot in Whiteboard to facilitate a collaborative brainstorming session that identifies potential project risks related to schedule, budget, security, and operations.
 
-- Copilot in PowerPoint to transform your project framework and risk analysis into a polished executive presentation. 
+- Copilot in PowerPoint to transform your project framework and risk analysis into a polished executive presentation.
 
 By the end of this exercise, you should experience how Microsoft 365 Copilot can act as an AI project assistant that accelerates planning, improves communication, and elevates the quality of your IT deliverables from concept to presentation.

--- a/Instructions/Labs/M03-empower-workforce-copilot-it/02-Ex1-introduction-project-planning-exercise.md
+++ b/Instructions/Labs/M03-empower-workforce-copilot-it/02-Ex1-introduction-project-planning-exercise.md
@@ -29,9 +29,8 @@ Over the course of this exercise, you plan to use the following Copilot features
 
 - Copilot Chat to synthesize input from project documents, emails, and chat logs and then build a clear project framework that defines goals, deliverables, milestones, risks, and stakeholders.
 
-- Copilot in Whiteboard to facilitate a collaborative brainstorming session that identifies potential project risks related to schedule, budget, security, and operations. 
+- Copilot in Whiteboard to facilitate a collaborative brainstorming session that identifies potential project risks related to schedule, budget, security, and operations.
 
 - Copilot in PowerPoint to transform your project framework and risk analysis into a polished executive presentation. 
-
 
 By the end of this exercise, you should experience how Microsoft 365 Copilot can act as an AI project assistant that accelerates planning, improves communication, and elevates the quality of your IT deliverables from concept to presentation.

--- a/Instructions/Labs/M03-empower-workforce-copilot-it/03-Ex1-1-use-chat-define-project-framework.md
+++ b/Instructions/Labs/M03-empower-workforce-copilot-it/03-Ex1-1-use-chat-define-project-framework.md
@@ -15,67 +15,70 @@ lab:
 ---
 This task demonstrates how Copilot Chat can accelerate the early stages of project planning and ensure alignment across IT, business, and leadership teams.
 
-You’re the lead member of Boulder Innovation’s IT team responsible for implementing the Network Modernization and Security Upgrade Project. Before any work can begin, the CIO wants a clear understanding of the project’s purpose, goals, deliverables, and stakeholders. The CIO tasked your team with gathering and synthesizing all relevant information from project documents, email threads, and chat logs to create a coherent project framework that guides the team’s planning and execution.
+You're the lead member of Boulder Innovation's IT team responsible for implementing the Network Modernization and Security Upgrade Project. Before any work can begin, the CIO wants a clear understanding of the project's purpose, goals, deliverables, and stakeholders. The CIO tasked your team with gathering and synthesizing all relevant information from project documents, email threads, and chat logs to create a coherent project framework that guides the team's planning and execution.
 
 To complete this task, you plan to use Microsoft 365 Copilot Chat to gather and synthesize information from multiple sources across their organization. In this scenario, Copilot Chat acts as a bridge between fragmented data—emails, Teams discussions, and project documents—allowing your IT team to quickly generate a unified view of project requirements and stakeholder expectations.
 
 > [!NOTE]
-> Since this course is based on a bring-your-own-subscription (BYOS) model, it doesn’t use a simulated lab/demo environment for Boulder Innovations. As such, there’s no Microsoft 365 system to access. To address this situation, this lab uses simulated emails, which are presented in Word (.docx) files. They include sender, recipient, subject, date, and message content. Even though this task uses Word documents to emulate email threads, Copilot Chat can read and summarize the content just like it would with real emails. Similarly, the Teams chat messages are provided in a text (.txt) file to simulate real project discussions in a simple, accessible format. In a real corporate environment, these conversations would be stored in Teams, but for this training exercise, the text file allows all learners to upload and use the content with Copilot Chat without needing access to a live Teams channel. The format preserves the sender, timestamp, and message content, so you can practice summarizing and extracting key information exactly as you would with actual chat messages.  
+> Since this course is based on a bring-your-own-subscription (BYOS) model, it doesn't use a simulated lab/demo environment for Boulder Innovations. As such, there's no Microsoft 365 system to access. To address this situation, this lab uses simulated emails, which are presented in Word (.docx) files. They include sender, recipient, subject, date, and message content. Even though this task uses Word documents to emulate email threads, Copilot Chat can read and summarize the content just like it would with real emails. Similarly, the Teams chat messages are provided in a text (.txt) file to simulate real project discussions in a simple, accessible format. In a real corporate environment, these conversations would be stored in Teams, but for this training exercise, the text file allows all learners to upload and use the content with Copilot Chat without needing access to a live Teams channel. The format preserves the sender, timestamp, and message content, so you can practice summarizing and extracting key information exactly as you would with actual chat messages.  
 
 #### Using Copilot Chat
 
 In Copilot Chat on the web, the response mode selector lets you control how much time and reasoning Copilot uses when answering your prompt. You can leave it set to **Auto** (the default option) so Copilot balances speed and depth for you, or choose a faster or more in depth response style depending on the task.
 
-When Copilot Chat opens in **Work** mode, the response mode selector isn’t shown. In **Work** mode, Copilot is optimized for secure, work context queries, so it automatically manages response depth for you. When you switch to **Web** mode, the response mode selector appears, allowing you to choose between faster responses or deeper reasoning. Once the selector is enabled, it remains visible as you switch between **Work** and **Web** modes.
+In **Work** mode, Copilot is optimized for secure, work-context queries, while **Web** mode retrieves external information from public sources. In either mode, you can use the response mode selector to choose between faster responses or deeper reasoning, or leave it set to **Auto** to let Copilot decide the appropriate response depth.
 
-If you’ve used Copilot in Excel, you know that it also includes a response control selector. However, its options are different from the Chat selector. In Copilot Chat, the selector controls how deeply Copilot reasons about your request. In Excel, the selector controls which AI model performs the work. Although these selectors might look similar, they control different aspects of Copilot and aren't the same setting.
+If you've used Copilot in Excel, you know that it also includes a response control selector. However, its options are different from the Chat selector. In Copilot Chat, the selector controls how deeply Copilot reasons about your request. In Excel, the selector controls which AI model performs the work. Although these selectors might look similar, they control different aspects of Copilot and aren't the same setting.
 
-This task uses **Work** mode, so the response mode selector doesn’t apply.
+This task uses the default **Auto** selector mode.
 
 Perform the following steps to complete this task:
 
-1.  The following documents emulate various emails, Teams messages, and documents across Boulder Innovations (BI) that reference the Network Modernization and Security Upgrade Project. Select each of the following links to download their respective files and store them in your OneDrive account:
+1. The following documents emulate various emails, Teams messages, and documents across Boulder Innovations (BI) that reference the Network Modernization and Security Upgrade Project. Select each of the following links to download their respective files and store them in your OneDrive account:
+
     - [**BI Project Proposal Draft.docx**](https://go.microsoft.com/fwlink/?linkid=2347512)
     - [**BI Email Thread – Budget Discussion.docx**](https://go.microsoft.com/fwlink/?linkid=2347806)
     - [**BI Teams Chat Export.txt**](https://go.microsoft.com/fwlink/?linkid=2347513)
     - [**BI Meeting Notes – Stakeholder Brief.docx**](https://go.microsoft.com/fwlink/?linkid=2347511)
     - [**BI Email – Vendor Quote Summary.docx**](https://go.microsoft.com/fwlink/?linkid=2347510)
     - [**BI Security Risk Memo.docx**](https://go.microsoft.com/fwlink/?linkid=2347807)
-        
-2.  In your Microsoft Edge browser, sign in to the **Microsoft 365** home page **(https://www.microsoft365.com)**.
 
-3.  In Microsoft 365 Copilot Chat, verify the **Work** tab is selected. In the prompt field, attach each of the files that you downloaded in step 1. Then ask Copilot to summarize all project requirements from those sources. It should identify key stakeholders and outline the project’s purpose, objectives, and expected deliverables. Have it Create a concise project framework summary that you can share with leadership. It should also map each section to its sources.
+2. In your Microsoft Edge browser, sign in to the **Microsoft 365 Copilot** home page [**https://m365.cloud.microsoft.com**](https://m365.cloud.microsoft.com).
+
+3. In Microsoft 365 Copilot Chat, verify the **Work** tab is selected. In the prompt field, attach each of the files that you downloaded in step 1. Then ask Copilot to summarize all project requirements from those sources. It should identify key stakeholders and outline the project's purpose, objectives, and expected deliverables. Have it Create a concise project framework summary that you can share with leadership. It should also map each section to its sources.
   
    > [!NOTE]
-   > For this first prompt, we’ve provided the text so you can see what an effective prompt looks like when it incorporates the four key elements discussed in the Introduction unit. You must write all remaining prompts in this exercise, but in doing so, you can use this prompt as a model to emulate.
+   > For this first prompt, we've provided the text so you can see what an effective prompt looks like when it incorporates the four key elements discussed in the Introduction unit. You must write all remaining prompts in this exercise, but in doing so, you can use this prompt as a model to emulate.
 
-   **Summarize Boulder Innovation’s ‘Network Modernization and Security Upgrade’ project using the attached documents. Create a concise framework for leadership that covers: purpose and scope, top objectives, key deliverables, milestones, risks, and stakeholders. Cite your sources (file names and dates) and note any conflicting details. Present the summary in short sections and bullet points, followed by an appendix that maps each section to its sources.**
+   **Summarize Boulder Innovation's 'Network Modernization and Security Upgrade' project using the attached documents. Create a concise framework for leadership that covers: purpose and scope, top objectives, key deliverables, milestones, risks, and stakeholders. Cite your sources (file names and dates) and note any conflicting details. Present the summary in short sections and bullet points, followed by an appendix that maps each section to its sources.**
 
-4.  Review the results. When you’re finished, ask Copilot to turn the results into a formatted Word document that you can download and share with the CIO.
+4. Review the results. When you're finished, ask Copilot to turn the results into a formatted Word document that you can download and share with the CIO.
 
-5.  Download the document that Copilot generated and move it from your **Downloads** folder to your **OneDrive** folder.
+5. Download the document that Copilot generated and move it from your **Downloads** folder to your **OneDrive** folder.
 
-6.  Open the file in Word and review it. Verify that it contains all the requested information.
+6. Open the file in Word and review it. Verify that it contains all the requested information.
 
-7.  On the **Home** tab ribbon, select **Copilot**. In the Copilot pane, verify the **Edit with Copilot** icon appears next to the plus (+) sign in the prompt field. If you don’t see it, select the plus sign and then select **Edit with Copilot** in the drop-down menu. The icon should now appear in the prompt field.
+7. In the bottom-right corner of the document, select the **Copilot** icon to open the Copilot pane. Verify the pane opens in edit mode—the heading should read **Let's edit your document**, and the prompt field should display the placeholder text **Describe what you'd like to edit**. Below the heading, confirm that the mode selector is set to **Allow editing** (so Copilot can edit your document directly). If it shows **Chat only**, select the drop-down and then select **Allow editing**.
 
-8.  After reviewing the document, you feel that it could use some visuals to enhance a few of the sections. Ask Copilot to suggest some images, charts, or SmartArt graphics that can enhance the content in the document.
+8. After reviewing the document, you feel that it could use some visuals to enhance a few of the sections. Ask Copilot to suggest some images, charts, or SmartArt graphics that can enhance the content in the document.
 
-9.  From the list of suggestions, select one that you would like Copilot to generate and ask it to generate that image.
+9. From the list of suggestions, select one that you would like Copilot to generate and ask it to generate that image.
 
    > [!NOTE]
    > Due to time constraints and the time it takes Copilot to generate images, limit your request to one image.
 
-10.	If Copilot indicates that it can’t generate or insert an image while Agent Mode is enabled (or it might refer to **Edit with Copilot** depending on your version), select the **Edit with Copilot** icon in the prompt field. Doing so exits **Edit with Copilot** mode. Then resubmit your prompt asking Copilot to generate your selected image.
+10. If Copilot indicates that it can't generate or insert an image while Agent Mode is enabled, select the **Edit** drop-down at the bottom of the Copilot pane and then select **Chat only**. Doing so switches Copilot out of editing mode so it can reply in chat. Then resubmit your prompt asking Copilot to generate your selected image.
 
-11.	Place your cursor in the document where you want Copilot to insert the image. Once Copilot generates the image in the Copilot pane, hover over the image and select the plus (+) sign that appears. Doing so inserts the image into the document at the location of your cursor. 
+11. Place your cursor in the document where you want Copilot to insert the image. Once Copilot generates the image in the Copilot pane, hover over the image and select the plus (+) sign that appears. Doing so inserts the image into the document at the location of your cursor.
 
-12.	If you had to exit **Edit with Copilot** mode to generate the image, then Return to **Edit with Copilot** mode by selecting the plus sign in the prompt field and then selecting **Edit with Copilot** in the drop-down menu.
+12. If you had to exit **Edit with Copilot** mode to generate the image, then Return to **Edit with Copilot** mode by selecting the drop-down above the prompt field and then selecting **Allow editing** in the drop-down menu.
 
-13.  Finally, you feel that a Question and Answer (Q&A) section would be helpful for leadership. Place your cursor at the end of the document, which is where you want Copilot to insert the Q&A section. Then ask Copilot to add a Q&A section in the document that includes potential questions and answers based on the document content.
+13. Finally, you feel that a Question and Answer (Q&A) section would be helpful for leadership. Place your cursor at the end of the document, which is where you want Copilot to insert the Q&A section. Then ask Copilot to add a Q&A section in the document that includes potential questions and answers based on the document content.
 
-14.  Review the Q&A section that Copilot inserted in the document. While it looks OK, you feel that some of the questions and answers simply rephrase existing document bullets. To enhance the Q&A material, ask Copilot to generate a different set of questions and answers that provoke deeper thinking, challenge assumptions, or connect the project to broader contexts.
+14. Review the Q&A section that Copilot inserted in the document. While it looks OK, you feel that some of the questions and answers simply rephrase existing document bullets. To enhance the Q&A material, ask Copilot to generate a different set of questions and answers that provoke deeper thinking, challenge assumptions, or connect the project to broader contexts.
 
-15.  Review the enhanced Q&A section. The deeper questions and insights are much more to your liking. Before you wrap up this document, review the suggested prompts that are displayed at the end of the Copilot pane. If you’re interested in making one of the suggested changes, then select the associated prompt and submit the request now.
+15. Review the enhanced Q&A section. The deeper questions and insights are much more to your liking. Before you wrap up this document, review the suggested prompts that are displayed at the end of the Copilot pane. If you're interested in making one of the suggested changes, then select the associated prompt and submit the request now.
 
-16.  You plan to use this document in Task 3 as the basis for an executive presentation, so make note of the file name in your OneDrive.
+16. Select **Done** to save the changes that Copilot made to the document.
+
+17. You plan to use this document in Task 3 as the basis for an executive presentation, so make note of the file name in your OneDrive.

--- a/Instructions/Labs/M03-empower-workforce-copilot-it/04-Ex1-2-use-whiteboard-identify-risks.md
+++ b/Instructions/Labs/M03-empower-workforce-copilot-it/04-Ex1-2-use-whiteboard-identify-risks.md
@@ -9,7 +9,7 @@ lab:
 
 # Exercise 1, Task 2: Use Copilot in Whiteboard to identify potential risks
 ---
-As the project moves into the planning phase, your IT team needs to identify potential risks that might affect schedule, budget, security, or operations. You’re responsible for facilitating a collaborative brainstorming session to capture and categorize all risks associated with the project. To achieve this goal, you plan to use Copilot in Microsoft Whiteboard to document these risks and group them into categories. Doing so can aid the IT team in developing mitigation strategies. Copilot in Whiteboard should base this list of risks on the project framework summary Word document that you created in Task 1 for the Network Modernization and Security Upgrade project.
+As the project moves into the planning phase, your IT team needs to identify potential risks that might affect schedule, budget, security, or operations. You're responsible for facilitating a collaborative brainstorming session to capture and categorize all risks associated with the project. To achieve this goal, you plan to use Copilot in Microsoft Whiteboard to document these risks and group them into categories. Doing so can aid the IT team in developing mitigation strategies. Copilot in Whiteboard should base this list of risks on the project framework summary Word document that you created in Task 1 for the Network Modernization and Security Upgrade project.
 
 Think of this exercise as basically an AI-assisted sticky-note exercise. Have you ever participated in a brainstorming session before that involved sticky notes? Meeting attendees write ideas on sticky notes and then stick them to a whiteboard or to a wall. From there, the meeting facilitator rearranges the notes by organizing them into various categories, removes duplicate ideas, edits ideas for clarification, and so on. When you finish the session, you end up with stacks of ideas, organized into categories.
 
@@ -17,61 +17,65 @@ Well, that's really what this exercise is - just a virtualized sticky-note exerc
 
 Perform the following steps to complete this task:
 
-1.  In the **Microsoft 365 Copilot Chat** window, select the **Apps** icon in the navigation pane. In the **Apps** menu that appears, select **All apps**. Under the top section of apps in the **Apps** window, select **All apps→**. In the **All apps** window, scroll down and select **Whiteboard**.
+1. In the **Microsoft 365 Copilot Chat** window, select the **Apps** icon in the navigation pane. In the **Apps** menu that appears, select **All apps**. Under the top section of apps in the **Apps** window, select **All apps→**. In the **All apps** window, scroll down and select **Whiteboard**.
 
-2.  In **Whiteboard for the web**, start a new Whiteboard session.
+   > [!NOTE]
+   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Whiteboard** from the list of apps that appears.
 
-3.  The **Board name** for this session defaults to **Whiteboard X** (where X is a number). Select this field and change the **Board name** to **Project Risks – Network Modernization**.
+2. In **Whiteboard for the web**, start a new Whiteboard session by selecting **New Whiteboard**.
 
-4.  Select the **Copilot** icon next to the menu bar at the bottom of the page and then select **Suggest** from the menu that appears.
+3. Skip any welcome messages that appear.
 
-5.  In the **Suggest content with Copilot** window, ask Copilot in Whiteboard to suggest a list of possible risks to upgrading a company’s corporate network infrastructure to improve performance, enhance cybersecurity, and support hybrid work.
+4. The **Board name** for this session defaults to **Whiteboard X** (where X is a number) or **Whiteboard**. Select this field and change the **Board name** to **Project Risks – Network Modernization**.
 
-6.  By default, Copilot in Whiteboard generates ideas in groups of six. In the **Suggest content with Copilot** window that appears, note the first six ideas that it generated. Copilot gives you two options here - you can either attach the ideas to your whiteboard if you're satisfied with the suggestions, or you can have Copilot generate more suggestions. Notice how the **Insert (6)** button indicates the number of ideas that Copilot generated - in this case, six. While six suggestions are a good starting point, you want to dig deeper into the potential risks, so select the **Generate more** button. Note how Copilot generated another six ideas, so the **Insert (12)** button now displays 12.  
-    <br/>Generate at least 18 risks, if not more, and then insert them on to your Whiteboard canvas.
+5. Select the **Copilot** icon next to the menu bar at the bottom of the page and then select **Suggest** from the menu that appears.
 
-7.  Notice how Copilot attaches the suggested ideas to your whiteboard in the form of yellow sticky notes. As with a real-world brainstorming session involving actual sticky notes, you can edit a particular note, delete it, lock it from future removal, and so on. In Microsoft Whiteboard, these activities are supported through standard whiteboarding functionality. If you haven't used Whiteboard before, try selecting (double-click) a specific note, and then in the menu bar that appears above it, you can select the **Edit text** (pencil) icon or any of the other options. Selecting the ellipsis icon at the end of the menu bar displays a menu of more options, such as deleting the note. Again, the idea behind Microsoft Whiteboard is to mimic real-world sticky-note exercises. Feel free to edit any note as you wish.
+6. In the **Suggest content with Copilot** dialog, ask Copilot in Whiteboard to suggest a list of possible risks to upgrading a company's corporate network infrastructure to improve performance, enhance cybersecurity, and support hybrid work.
 
-8.  In looking at the risks, you notice that there are few, if any associated with network downtime. Select the **Copilot** icon at the bottom of the page and then select **Suggest** from the menu.
+7. By default, Copilot in Whiteboard generates ideas in groups of six. In the **Suggest content with Copilot** dialog that appears, note the first six ideas that it generated. Copilot gives you two options here - you can either attach the ideas to your whiteboard if you're satisfied with the suggestions, or you can have Copilot generate more suggestions. Notice how the **Insert (6)** button indicates the number of ideas that Copilot generated - in this case, six. While six suggestions are a good starting point, you want to dig deeper into the potential risks, so select the **Generate more** button. Note how Copilot generated another six ideas, so the **Insert (12)** button now displays 12.  
 
-9.  In the **Suggest content with Copilot** window that appears, ask Copilot to suggest any risks associated with system downtime.
+    Generate at least 18 risks, if not more, and then insert them onto your Whiteboard canvas.
 
-10. Insert the six risk mitigation ideas associated with system downtime. Note how the block of six notes is highlighted with a line around the block. This block of notes is known as a note grid. You can move or resize a note grid just like any other element on your whiteboard. As you resize a note grid, the sizes of all the sticky notes inside it adjust accordingly. If the block of six notes overlays on top of one of the existing blocks of notes, select one of the outside lines around the note grid and drag the entire block of six notes to the side so that it doesn't overlay any of the previous notes. If you run out of space on the screen and part of the block falls off the screen, select the **Fit to Screen** icon on the bottom-right corner of the page to display all the notes on the screen (the **Fit to screen** icon appears when a block is partially off the screen). You might need to select the icon more than once to fit the content onto the screen.
+8. Notice how Copilot attaches the suggested ideas to your whiteboard in the form of yellow sticky notes. As with a real-world brainstorming session involving actual sticky notes, you can edit a particular note, delete it, lock it from future removal, and so on. In Microsoft Whiteboard, these activities are supported through standard whiteboarding functionality. If you haven't used Whiteboard before, try selecting (double-click) a specific note, and then in the menu bar that appears above it, you can select the **Edit text** (pencil) icon or any of the other options. Selecting the ellipsis icon at the end of the menu bar displays a menu of more options, such as deleting the note. Again, the idea behind Microsoft Whiteboard is to mimic real-world sticky-note exercises. Feel free to edit any note as you wish.
 
-11. After making one last review of your Whiteboard, you identified a note that you want to remove. Select a note that you no longer want, and then in the icon tray that appears, select the ellipsis icon and then select the **Delete** option.
+9. In looking at the risks, you notice that there are few, if any, associated with network downtime. Select the **Copilot** icon at the bottom of the page and then select **Suggest** from the menu.
 
-12. At this point, you should be done editing the notes. You now want Copilot to organize them by category. When you categorize notes, Copilot determines the names of the categories and organizes the notes accordingly.
+10. In the **Suggest content with Copilot** window that appears, ask Copilot to suggest any risks associated with system downtime.
+
+11. Insert the six risk mitigation ideas associated with system downtime. Note how the block of six notes is highlighted with a line around the block. This block of notes is known as a note grid. You can move or resize a note grid just like any other element on your whiteboard. As you resize a note grid, the sizes of all the sticky notes inside it adjust accordingly. If the block of six notes overlays on top of one of the existing blocks of notes, select one of the outside lines around the note grid and drag the entire block of six notes to the side so that it doesn't overlay any of the previous notes. If you run out of space on the screen and part of the block falls off the screen, select the **Fit to Screen** icon on the bottom-right corner of the page to display all the notes on the screen (the **Fit to screen** icon appears when a block is partially off the screen). You might need to select the icon more than once to fit the content onto the screen.
+
+12. After making one last review of your Whiteboard, you identified a note that you want to remove. Select a note that you no longer want, and then in the icon tray that appears, select the ellipsis icon and then select the **Delete** option.
+
+13. At this point, you should be done editing the notes. You now want Copilot to organize them by category. When you categorize notes, Copilot determines the names of the categories and organizes the notes accordingly.
 
    > [!WARNING]
-   > When you choose the option to categorize your notes, Whiteboard automatically selects the sticky notes that are currently in view on the canvas. In doing so, it displays the selected notes within a border. Notes outside the current viewport aren’t included within this border, so if you proceed immediately, those notes that are outside the border aren’t categorized.
+   > When you choose the option to categorize your notes, Whiteboard automatically selects the sticky notes that are currently in view on the canvas. In doing so, it displays the selected notes within a border. Notes outside the current viewport aren't included within this border, so if you proceed immediately, those notes that are outside the border aren't categorized.
 
-13.  There are two ways to expand the selection so that all notes are included within the border:
+14. There are two ways to expand the selection so that all notes are included within the border:
 
-        - **Show more notes on the screen**. When you select the Copilot option to categorize notes, Copilot grabs everything that’s in view and places them within the border. To avoid the situation where Copilot doesn’t include all the notes within the border, zoom out or pan until all the notes you want are visible.
-    
-        - **Select everything explicitly using a keyboard command**. Press **Ctrl+A** to select all objects on the canvas, including sticky notes that aren’t in view. Select one of the edges of the border and drag the entire selection of notes into the view on the canvas so that you can see all the notes.
-      
-        For the purpose of this task, select **Ctrl+A** to select all the notes.
+      - **Show more notes on the screen**. When you select the Copilot option to categorize notes, Copilot grabs everything that's in view and places it within the border. To avoid the situation where Copilot doesn't include all the notes within the border, zoom out or pan until all the notes you want are visible.
 
-14.  Note how Copilot selected all the sticky notes, even ones that weren’t currently in view on the canvas. If some of the notes aren’t fully in view on the canvas, select one of the edges of the border and drag the entire selection into the canvas so that all the notes are visible.
+      - **Select everything explicitly using a keyboard command**. Press **Ctrl+A** to select all objects on the canvas, including sticky notes that aren't in view. Select one of the edges of the border and drag the entire selection of notes into the view on the canvas so that you can see all the notes.
 
-15.  With all the notes now appearing within view on the canvas, select the **Copilot** icon on the bottom of the window and select the **Categorize** option in the menu. Doing so displays a **Categorize selected notes** window. Select the **Categorize** button that appears in this window.
+      For the purpose of this task, select **Ctrl+A** to select all the notes.
 
-16.  Note what happened. Copilot generated a set of categories and reorganized the notes accordingly. It also assigned each category a different color to help identify the differences between categories. Sometimes the rectangle containing the notes is small and hard to read. If this situation occurs, select the **Fit to Screen** icon on the bottom-right corner of the page. You can select this icon multiple times until the image is large enough to read, but not too large that it exceeds the size of the screen.
+15. Note how Copilot selected all the sticky notes, even ones that weren't currently in view on the canvas. If some of the notes aren't fully in view on the canvas, select one of the edges of the border and drag the entire selection into the canvas so that all the notes are visible.
 
-17.  Note the icon tray that appears below the organized group of notes. If you aren’t satisfied with the categories, select the **Regenerate** button on the icon tray that appears.
+16. With all the notes now appearing within view on the canvas, select the **Copilot** icon on the bottom of the window and select the **Categorize** option in the menu. Doing so displays a **Categorize selected notes?** dialog. Select the **Categorize** button that appears in this dialog.
+
+17. Note what happened. Copilot generated a set of categories and reorganized the notes accordingly. It also assigned each category a different color to help identify the differences between categories. Sometimes the rectangle containing the notes is small and hard to read. If this situation occurs, select the **Fit to Screen** icon on the bottom-right corner of the page. You can select this icon multiple times until the image is large enough to read, but not too large that it exceeds the size of the screen.
+
+18. Note the icon tray that appears below the organized group of notes. If you aren't satisfied with the categories, select the **Regenerate** button on the icon tray that appears.
 
    > [!TIP]
    > You can select the **Regenerate** button as many times as needed until you're satisfied with the categories that Copilot provides. Select this button several times and note the changes that Copilot makes each time. Besides changing category names and relocating notes, Copilot may add or reduce the number of categories with each regeneration.
 
-18.  After regenerating the categories several times, you’re not sure which iteration you liked best. While Copilot doesn’t currently support going back to a previous categorization, it does allow you to start over. Select the **Revert** button to return to the starting list of yellow sticky notes.
+19. After regenerating the categories several times, you're not sure which iteration you liked best. While Copilot doesn't currently support going back to a previous categorization, it does allow you to start over. Select the **Revert** button to return to the starting list of yellow sticky notes.
 
-19.  To categorize the sticky notes once again, select the **Copilot** icon at the bottom of the page and then select **Categorize** from the menu. In the **Categorize selected notes?** window, select the **Categorize** button.
+20. To categorize the sticky notes once again, select the **Copilot** icon at the bottom of the page and then select **Categorize** from the menu. In the **Categorize selected notes?** window, select the **Categorize** button.
 
-20.  Now that you know how the **Regenerate** button works, for the sake of time, select it once or twice if necessary until you’re satisfied with the category results.
+21. Now that you know how the **Regenerate** button works, for the sake of time, select it once or twice if necessary until you're satisfied with the category results, and then select **Keep it** to keep the categories that Copilot generated.
 
-21.  At this point, you realize that you would like a short summary of the brainstorming session added to your whiteboard content. To do so, select the **Copilot** icon and then select the **Summarize** option.
+22. At this point, you realize that you would like a short summary of the brainstorming session added to your whiteboard content. To do so, select the **Copilot** icon and then select the **Summarize** option.
 
-22.  You now want to save this summarization to a Word document so that you can include it as a resource in the PowerPoint presentation you create in the next task. In the **Summary** window that Copilot creates in your Whiteboard, highlight the text and then copy it to your clipboard **(Ctrl+C)**. Open a blank Word document, paste in the Summary notes, and then save the file to your **OneDrive**. When you’re done, return to your Whiteboard.
-
-
+23. You now want to save this summarization to a Word document so that you can include it as a resource in the PowerPoint presentation you create in the next task. In the **Summary** window that Copilot creates in your Whiteboard, highlight the text and then copy it to your clipboard **(Ctrl+C)**. Open a blank Word document, paste in the Summary notes, and then save the file to your **OneDrive**. When you're done, return to your Whiteboard.

--- a/Instructions/Labs/M03-empower-workforce-copilot-it/04-Ex1-2-use-whiteboard-identify-risks.md
+++ b/Instructions/Labs/M03-empower-workforce-copilot-it/04-Ex1-2-use-whiteboard-identify-risks.md
@@ -17,10 +17,7 @@ Well, that's really what this exercise is - just a virtualized sticky-note exerc
 
 Perform the following steps to complete this task:
 
-1. In the **Microsoft 365 Copilot Chat** window, select the **Apps** icon in the navigation pane. In the **Apps** menu that appears, select **All apps**. Under the top section of apps in the **Apps** window, select **All apps→**. In the **All apps** window, scroll down and select **Whiteboard**.
-
-   > [!NOTE]
-   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Whiteboard** from the list of apps that appears.
+1. In the **Microsoft 365 Copilot Chat** window, select the **App Launcher** (grid icon) in the top left corner of the page, and then select **More Apps**. In the **All apps→** window, scroll down and select **Whiteboard**. 
 
 2. In **Whiteboard for the web**, start a new Whiteboard session by selecting **New Whiteboard**.
 

--- a/Instructions/Labs/M03-empower-workforce-copilot-it/05-Ex1-3-use-powerpoint-create-presentation.md
+++ b/Instructions/Labs/M03-empower-workforce-copilot-it/05-Ex1-3-use-powerpoint-create-presentation.md
@@ -25,10 +25,7 @@ This task uses the **Edit with Copilot** functionality.
 
 Perform the following steps to complete this task:
 
-1. In your Microsoft Edge browser, go to the **Microsoft 365** home page, select **Apps** in the navigation pane, and then select **PowerPoint** from the **Apps** menu.
-
-   > [!NOTE]
-   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **PowerPoint** from the list of apps that appears.
+1. In your Microsoft Edge browser, go to the **Microsoft 365** home page, select the **App Launcher** (grid icon), select **More Apps**, and then select **PowerPoint** from the list of available apps.
 
 2. In **PowerPoint for the web**, create a blank presentation.
 

--- a/Instructions/Labs/M03-empower-workforce-copilot-it/05-Ex1-3-use-powerpoint-create-presentation.md
+++ b/Instructions/Labs/M03-empower-workforce-copilot-it/05-Ex1-3-use-powerpoint-create-presentation.md
@@ -13,35 +13,38 @@ Boulder's CIO asked you to present a briefing on the status of the Network Moder
 
 #### Using Copilot in PowerPoint
 
-PowerPoint provides two ways to use Copilot: standard Copilot prompts for quickly generating slide content or summaries, and **Edit with Copilot** in the Copilot pane for making direct, in place edits to slides, layouts, and presentation structure. 
+PowerPoint provides two ways to use Copilot: standard Copilot prompts for quickly generating slide content or summaries, and **Edit with Copilot** in the Copilot pane for making direct, in-place edits to slides, layouts, and presentation structure. 
 
-- You should use Copilot’s standard prompts in PowerPoint when you want to draft slides quickly, summarize content, or generate speaker notes without changing the structure of the deck. When using the Copilot pane, if you enter a prompt without selecting **Edit with Copilot**, Copilot responds in a chat style mode that generates suggestions or content separately, rather than making direct, in place changes to the presentation. 
+- You should use Copilot's standard prompts in PowerPoint when you want to draft slides quickly, summarize content, or generate speaker notes without changing the structure of the deck. When using the Copilot pane, if you enter a prompt without selecting **Edit with Copilot**, Copilot responds in a chat-style mode that generates suggestions or content separately, rather than making direct, in-place changes to the presentation. 
 
-- You should use **Edit with Copilot** when you want Copilot to work directly in the presentation—such as reorganizing slides, refining slide text, improving layouts, or making iterative edits across multiple slides. **Edit with Copilot** is optimized for in place presentation work, so it understands slide structure and can apply changes directly to the deck, rather than just suggesting content in a separate response. 
+- You should use **Edit with Copilot** when you want Copilot to work directly in the presentation—such as reorganizing slides, refining slide text, improving layouts, or making iterative edits across multiple slides. **Edit with Copilot** is optimized for in-place presentation work, so it understands slide structure and can apply changes directly to the deck, rather than just suggesting content in a separate response. 
 
-In summary, use chat style Copilot for thinking and generating ideas; use **Edit with Copilot** for hands on editing inside the file. Copilot typically previews slide or layout changes and, once you confirm, it applies those changes directly to the slide deck rather than expecting the user to explicitly apply them through copy and paste.
+In summary, use chat-style Copilot for thinking and generating ideas; use **Edit with Copilot** for hands-on editing inside the file. Copilot typically previews slide or layout changes and, once you confirm, it applies those changes directly to the slide deck rather than expecting the user to explicitly apply them through copy and paste.
 
 This task uses the **Edit with Copilot** functionality.
 
 Perform the following steps to complete this task:
 
-1.  In your Microsoft Edge browser, go to the **Microsoft 365** home page, select **Apps** in the navigation pane, and then select **PowerPoint** from the **Apps** menu.
+1. In your Microsoft Edge browser, go to the **Microsoft 365** home page, select **Apps** in the navigation pane, and then select **PowerPoint** from the **Apps** menu.
 
-2.  In **PowerPoint for the web**, create a blank presentation.
+   > [!NOTE]
+   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **PowerPoint** from the list of apps that appears.
 
-3.	Select the **Home** tab if the **Home** tab ribbon doesn’t appear. Then select **Copilot** at the end of the **Home** tab ribbon. 
+2. In **PowerPoint for the web**, create a blank presentation.
 
-4.	In the Copilot pane, select the plus (+) sign in the prompt field and then select **Add work content** in the drop-down menu. Attach the Word files that you created in tasks 1 and 2. 
+3. Select the **Copilot** icon in the bottom-right corner of the PowerPoint window to open the Copilot pane.
 
-5.	Verify the **Edit with Copilot** icon appears next to the plus (+) sign in the prompt field. If you don’t see it, select the plus sign and then select **Edit with Copilot** in the drop-down menu. The icon should now appear in the prompt field. 
+4. In the Copilot pane, select the plus **(+)** sign in the prompt field and then select **Add work content** in the drop-down menu. Attach the Word files that you created in tasks 1 and 2. 
+
+5. Verify the dropdown above the prompt field is set to **Allow editing**. This ensures Copilot can make direct, in-place edits to the presentation. If you see **Chat only** selected, select the dropdown and choose **Allow editing**.
 
 6. Ask Copilot to create an executive presentation for the Network Modernization project. The presentation should summarize the key information from the two attached files. 
 
-7.	If Copilot asks a series of questions related to the presentation, select the answers that you want it to apply. Select the **Confirm** button once you finish answering the questions. It might also ask a second series of questions, one of which might be to select a slide template. Keep in mind that if you don’t select a template, Copilot simply presents text on plain white slides. Again, select the answers that you want it to apply, or select **Skip all** if you want Copilot to use its best judgment.
+7. If Copilot asks a series of questions related to the presentation, select the answers that you want it to apply. Select the **Confirm** button once you finish answering the questions. It might also ask a second series of questions, one of which might be to select a slide template. Keep in mind that if you don’t select a template, Copilot simply presents text on plain white slides. Again, select the answers that you want it to apply, or select **Skip all** if you want Copilot to use its best judgment.
 
-8.	Copilot in PowerPoint uses this information to generate a list of slides, which might take a few minutes.
+8. Copilot in PowerPoint uses this information to generate a list of slides, which might take a few minutes.
 
-9.  After reviewing the slides, you decide to add three discussion slides. You want to add a discussion slide for each of the following topics (these are the top three executive and CIO concerns for infrastructure and modernization projects):
+9. After reviewing the slides, you decide to add three discussion slides. You want to add a discussion slide for each of the following topics (these are the top three executive and CIO concerns for infrastructure and modernization projects):
 
     - Operational and business continuity risk
     - Security, compliance, and data protection
@@ -49,9 +52,9 @@ Perform the following steps to complete this task:
     
     Before requesting the new slides, you must first indicate where you want the slides to appear in the deck. In this case, you want to add these slides to the end of the presentation. In the slide pane on the left, scroll down to the end of the slides and select after the final slide. 
 
-10. Enter a prompt that asks Copilot to add a topic section slide titled **Discussions: Risk, Security, and Value**. This topic should include three slides – one for **Operational and business continuity risk**, another for **Security, compliance, and data protection**, and a final slide for **Budget, value, and delivery confidence**. Again, it might take Copilot a minute or two to add these new slides. 
+10. Enter a prompt that asks Copilot to add a topic section slide titled **Discussions: Risk, Security, and Value**. This topic should include three slides – one for **Operational and business continuity risk**, another for **Security, compliance, and data protection**, and a final slide for **Budget, value, and delivery confidence**. If Copilot asks where it should insert the new slides, select the option that adds them to the end of the presentation. Again, it might take Copilot a minute or two to add these new slides. 
 
-11.  Scroll down to the end of the slide deck. The final four slides should include the newly added **Discussions: Risk, Security, and Value** topic and its three discussion slides. Review each of the slides that Copilot generated for this topic. While the discussion points that Copilot generated for each of the slides is OK, you decide that you want to include a different set of talking points. Ask Copilot to replace any existing content on the following slides with the following talking points (this might take a few minutes):
+11. Scroll down to the end of the slide deck. The final four slides should include the newly added **Discussions: Risk, Security, and Value** topic and its three discussion slides. Review each of the slides that Copilot generated for this topic. While the discussion points that Copilot generated for each of the slides are OK, you decide that you want to include a different set of talking points. Ask Copilot to replace any existing content on the following slides with the following talking points (this might take a few minutes):
 
         - **Operational and business continuity risk**
             - Do you anticipate downtime or service interruptions?
@@ -68,6 +71,6 @@ Perform the following steps to complete this task:
             - Delays and missed milestones
             - Clear, measurable outcomes and ROI
 
-12.  Review the three slides to verify that Copilot made the changes as requested. Also review any of Copilot’s suggestions at the end of the chat. Feel free to ask it to make any of the suggested changes that are of interest to you. 
+12. Review the three slides to verify that Copilot made the changes as requested. Also review any of Copilot’s suggestions at the end of the chat. Feel free to ask it to make any of the suggested changes that are of interest to you. 
 
 13. Once you're satisfied with the PowerPoint file, save it to your OneDrive account.

--- a/Instructions/Labs/M03-empower-workforce-copilot-it/06-Ex2-introduction-transform-adoption-exercise.md
+++ b/Instructions/Labs/M03-empower-workforce-copilot-it/06-Ex2-introduction-transform-adoption-exercise.md
@@ -23,7 +23,7 @@ As the IT Manager at VanArsdel, Ltd., a 2,500-employee engineering and manufactu
 
 The company is preparing to roll out several new Microsoft 365 features over the next quarter, from AI-powered meeting summaries to enhanced file collaboration and security updates. However, past launches at VanArsdel showed that technical readiness alone isn't enough. The company learned the hard way that without clear communication, engaging education, and active feedback loops, adoption can stall and user frustration can rise.
 
-To prevent a repeat of past failures, the CIO issued a directive for IT to lead a “90-Day Feature Awareness Campaign” designed to drive adoption and minimize confusion. The campaign must combine clear communication, data-driven insights, and user-friendly resources that empower employees to embrace the new tools with confidence. Your goal is to use Microsoft 365 Copilot to help you plan, communicate, and measure the effect of this initiative—turning what used to be weeks of manual effort into hours of streamlined, AI-assisted work.
+To prevent a repeat of past failures, the CIO issued a directive for IT to lead a "90-Day Feature Awareness Campaign" designed to drive adoption and minimize confusion. The campaign must combine clear communication, data-driven insights, and user-friendly resources that empower employees to embrace the new tools with confidence. Your goal is to use Microsoft 365 Copilot to help you plan, communicate, and measure the effect of this initiative—turning what used to be weeks of manual effort into hours of streamlined, AI-assisted work.
 
 Throughout this exercise, you plan to use the following Microsoft 365 Copilot features to guide the campaign from research to analysis:
 

--- a/Instructions/Labs/M03-empower-workforce-copilot-it/06-Ex2-introduction-transform-adoption-exercise.md
+++ b/Instructions/Labs/M03-empower-workforce-copilot-it/06-Ex2-introduction-transform-adoption-exercise.md
@@ -12,22 +12,22 @@ lab:
 
 # Exercise 2: Transform feature launches and adoption using Microsoft 365 Copilot
 ---
-Microsoft 365 Copilot is transforming how IT professionals plan, communicate, and measure technology adoption across their organizations. For IT teams, successful adoption isn’t just about deploying new tools—it’s about ensuring employees understand, embrace, and actively use them. Copilot can streamline every step of that process by helping IT professionals quickly discover upcoming Microsoft 365 features, create clear and engaging communications for end users, and develop practical resources such as announcements, best-practice guides, and training materials.
+Microsoft 365 Copilot is transforming how IT professionals plan, communicate, and measure technology adoption across their organizations. For IT teams, successful adoption isn't just about deploying new tools—it's about ensuring employees understand, embrace, and actively use them. Copilot can streamline every step of that process by helping IT professionals quickly discover upcoming Microsoft 365 features, create clear and engaging communications for end users, and develop practical resources such as announcements, best-practice guides, and training materials.
 
 > [!TIP]
 > The Introduction unit in this module reminded you of the four key elements of an effective prompt: Goal, Context, Sources, and Expectations. Keep these elements in mind as you create prompts in this exercise.
 
 ### Scenario
 
-As the IT Manager at VanArsdel, Ltd., a 2,500-employee engineering and manufacturing company operating across three regions, you play a key role in helping the organization stay productive, connected, and secure. VanArsdel’s leadership recently announced a company-wide initiative to accelerate Microsoft 365 feature adoption. It wants to ensure that employees not only have access to new tools, but also understand how to use them effectively to improve collaboration and streamline daily work.
+As the IT Manager at VanArsdel, Ltd., a 2,500-employee engineering and manufacturing company operating across three regions, you play a key role in helping the organization stay productive, connected, and secure. VanArsdel's leadership recently announced a company-wide initiative to accelerate Microsoft 365 feature adoption. It wants to ensure that employees not only have access to new tools, but also understand how to use them effectively to improve collaboration and streamline daily work.
 
-The company is preparing to roll out several new Microsoft 365 features over the next quarter, from AI-powered meeting summaries to enhanced file collaboration and security updates. However, past launches at VanArsel showed that technical readiness alone isn’t enough. The company learned the hard way that without clear communication, engaging education, and active feedback loops, adoption can stall and user frustration can rise.
+The company is preparing to roll out several new Microsoft 365 features over the next quarter, from AI-powered meeting summaries to enhanced file collaboration and security updates. However, past launches at VanArsdel showed that technical readiness alone isn't enough. The company learned the hard way that without clear communication, engaging education, and active feedback loops, adoption can stall and user frustration can rise.
 
 To prevent a repeat of past failures, the CIO issued a directive for IT to lead a “90-Day Feature Awareness Campaign” designed to drive adoption and minimize confusion. The campaign must combine clear communication, data-driven insights, and user-friendly resources that empower employees to embrace the new tools with confidence. Your goal is to use Microsoft 365 Copilot to help you plan, communicate, and measure the effect of this initiative—turning what used to be weeks of manual effort into hours of streamlined, AI-assisted work.
 
 Throughout this exercise, you plan to use the following Microsoft 365 Copilot features to guide the campaign from research to analysis:
 
-- Copilot Chat to research and summarize the top eight upcoming Microsoft 365 features most relevant to VanArsdel users. Y
+- Copilot Chat to research and summarize the top eight upcoming Microsoft 365 features most relevant to VanArsdel users.
 
 - Copilot in Viva Engage to create an engaging announcement post that builds awareness and excitement about the new features, along with a Viva community where employees can share questions, ideas, and feedback.
 

--- a/Instructions/Labs/M03-empower-workforce-copilot-it/07-Ex2-1-use-chat-identify-upcoming-features.md
+++ b/Instructions/Labs/M03-empower-workforce-copilot-it/07-Ex2-1-use-chat-identify-upcoming-features.md
@@ -29,7 +29,7 @@ This task uses the default **Auto** selector mode.
 
 Perform the following steps to complete this task:
 
-1. In your Microsoft Edge browser, sign in to the **Microsoft 365 Copilot** home page **(https://www.microsoft365.com)**. Since the scenario involves finding future features that are published by Microsoft and not stored in VanArsdel's tenant, select the **Web** option rather than the **Work** option. Leave the response mode selector set to **Auto**.
+1. In your Microsoft Edge browser, sign in to the **Microsoft 365 Copilot** home page [**https://m365.cloud.microsoft.com**](https://m365.cloud.microsoft.com). Since the scenario involves finding future features that are published by Microsoft and not stored in VanArsdel's tenant, select the **Web** option rather than the **Work** option. Leave the response mode selector set to **Auto**.
 
 2. Copy and paste in the following prompt that asks Copilot to summarize the upcoming Microsoft 365 features:
   

--- a/Instructions/Labs/M03-empower-workforce-copilot-it/07-Ex2-1-use-chat-identify-upcoming-features.md
+++ b/Instructions/Labs/M03-empower-workforce-copilot-it/07-Ex2-1-use-chat-identify-upcoming-features.md
@@ -13,7 +13,7 @@ lab:
 
 # Exercise 2, Task 1: Use Microsoft 365 Copilot Chat to identify upcoming Microsoft 365 features
 ---
-In preparation for VanArsdel’s upcoming IT leadership meeting, you must create a summary of upcoming Microsoft 365 features that might affect users in the next quarter. You need this information quickly so that your IT team can plan communication and support strategies. Your goal is to identify and summarize the most relevant new features that can affect VanArsdel’s end users within the next 90 days, with notes on potential IT actions.
+In preparation for VanArsdel's upcoming IT leadership meeting, you must create a summary of upcoming Microsoft 365 features that might affect users in the next quarter. You need this information quickly so that your IT team can plan communication and support strategies. Your goal is to identify and summarize the most relevant new features that can affect VanArsdel’s end users within the next 90 days, with notes on potential IT actions.
 
 Historically, this process required your team to review blogs and admin center updates, consolidate findings, assess each feature’s implications for end users, evaluate its operational effect on IT, and prioritize the eight most significant items for presentation. Now, instead of spending hours completing this process, you plan to use Microsoft 365 Copilot Chat to gather and summarize what’s coming—all in about a minute, showcasing the dramatic time savings Copilot delivers.
 

--- a/Instructions/Labs/M03-empower-workforce-copilot-it/07-Ex2-1-use-chat-identify-upcoming-features.md
+++ b/Instructions/Labs/M03-empower-workforce-copilot-it/07-Ex2-1-use-chat-identify-upcoming-features.md
@@ -19,9 +19,9 @@ Historically, this process required your team to review blogs and admin center u
 
 #### Using Copilot Chat
 
-In Copilot Chat on the web, the response mode selector lets you control how much time and reasoning Copilot uses when answering your prompt. You can leave it set to **Auto** (the default option) so Copilot balances speed and depth for you, or choose a faster or more in depth response style depending on the task.
+In Copilot Chat on the web, the response mode selector lets you control how much time and reasoning Copilot uses when answering your prompt. You can leave it set to **Auto** (the default option) so Copilot balances speed and depth for you, or choose a faster or more in-depth response style depending on the task.
 
-When Copilot Chat opens in **Work** mode, the response mode selector isn’t shown. In **Work** mode, Copilot is optimized for secure, work context queries, so it automatically manages response depth for you. When you switch to **Web** mode, the response mode selector appears, allowing you to choose between faster responses or deeper reasoning. Once the selector is enabled, it remains visible as you switch between **Work** and **Web** modes.
+In **Work** mode, Copilot is optimized for secure, work-context queries, while **Web** mode retrieves external information from public sources. In either mode, you can use the response mode selector to choose between faster responses or deeper reasoning, or leave it set to **Auto** to let Copilot decide the appropriate response depth.
 
 If you’ve used Copilot in Excel, you know that it also includes a response control selector. However, its options are different from the Chat selector. In Copilot Chat, the selector controls how deeply Copilot reasons about your request. In Excel, the selector controls which AI model performs the work. Although these selectors might look similar, they control different aspects of Copilot and aren't the same setting.
 
@@ -29,33 +29,33 @@ This task uses the default **Auto** selector mode.
 
 Perform the following steps to complete this task:
 
-1.  In your Microsoft Edge browser, sign in to the **Microsoft 365** home page **(https://www.microsoft365.com)**. Since the scenario involves finding future features that are published by Microsoft and not stored in VanArsdel’s tenant, select the **Web** option rather than the **Work** option. Leave the response mode selector set to **Auto**.
+1. In your Microsoft Edge browser, sign in to the **Microsoft 365 Copilot** home page **(https://www.microsoft365.com)**. Since the scenario involves finding future features that are published by Microsoft and not stored in VanArsdel's tenant, select the **Web** option rather than the **Work** option. Leave the response mode selector set to **Auto**.
 
-2.  Copy and paste in the following prompt that asks Copilot to summarize the upcoming Microsoft 365 features:
+2. Copy and paste in the following prompt that asks Copilot to summarize the upcoming Microsoft 365 features:
   
    > [!NOTE]
    > For this first prompt, we’ve provided the text so you can see what an effective prompt looks like when it incorporates the four key elements discussed in the Introduction unit. You must write all remaining prompts in this exercise, but in doing so, you can use this prompt as a model to emulate.
 
    **I'm the IT Manager at VanArsdel, Ltd. Summarize the Microsoft 365 features likely to be released or generally available by Microsoft in the next 90 days that are most relevant to end users (such as collaboration, security, Teams, Outlook, SharePoint, Viva, and so on). Please list each feature along with the following information: a one-line description, why it matters for a non-technical end user, and any recommended action for IT (for example, communication, training, and change to tenant settings). Provide the result as a short bullet list (no more than 8 items).**
 
-3.  Review Copilot’s response. If it returns sources, verify a couple of them to ensure they're valid. If it returns ambiguous items, ask a clarifying follow-up question in the Chat.
+3. Review Copilot’s response. If it returns sources, verify a couple of them to ensure they're valid. If it returns ambiguous items, ask a clarifying follow-up question in the Chat.
 
-4.  At the end of the response, select the **Edit in Pages** icon.
+4. At the end of the response, select the ellipsis (...) and then select the **Edit in Pages** option.
 
-5.  When editing in **Pages**, note how Copilot displays the Copilot chat pane along with the Pages form. In the **Pages** form, select the **Create** button and then select **Document** in the drop-down menu. In the dialog box that appears, select **Open Word**, which opens the document in **Word for the web**. 
+5. When editing in **Pages**, note how Copilot displays the Copilot chat pane along with the Pages form. In the **Pages** form, select the **Create** button and then select **Document** in the drop-down menu. In the dialog box that appears, select **Open Word**, which opens the document in **Word for the web**. 
 
-6.  In **Word for the web**, Copilot copies its entire response into a document, including the extraneous chat content that appeared at the beginning and end of the chat. Delete any extraneous text that was pasted in as well. Tag or highlight items you want to prioritize for communications. 
+6. In **Word for the web**, Copilot copies its entire response into a document, including the extraneous chat content that appeared at the beginning and end of the chat. Delete any extraneous text that was pasted in as well. Tag or highlight items you want to prioritize for communications. 
 
-7.  In the Word document, select the **Copilot** option on the **Home** tab. Verify the **Edit with Copilot** icon appears in the prompt field next to the plus (+) sign. If you don’t see it, select the plus sign and then select **Edit with Copilot** in the drop-down menu. The icon should now appear in the prompt field.
+7. In the bottom-right corner of the Word document, select the **Copilot** icon to open the Copilot pane. Verify the pane opens in edit mode—the heading should read **Let's edit your document**, and the prompt field should display the placeholder text **Describe what you'd like to edit**. Below the heading, confirm that the mode selector is set to **Allow editing** (so Copilot can edit your document directly). If it shows **Chat only**, select the drop-down and then select **Allow editing**.
 
-8.	In the next step, you’re going to ask Copilot to add an executive summary to the document. Before doing so, you must first place your cursor at the location where you want Copilot to insert the summary. You want the summary to appear before the feature list, so position your cursor between the document title and the feature list. 
+8. In the next step, you're going to ask Copilot to add an executive summary to the document. Before doing so, you must first place your cursor at the location where you want Copilot to insert the summary. You want the summary to appear before the feature list, so position your cursor between the document title and the feature list. 
 
-9.	In the Copilot chat pane, ask Copilot to add a short executive summary based on the content in the document. 
+9. In the Copilot chat pane, ask Copilot to add a short executive summary based on the content in the document. 
  
-10.	Once Copilot adds the executive summary to the document, ask it to add a one-sentence risk or opportunity for each feature. 
+10. Once Copilot adds the executive summary to the document, ask it to add a one-sentence risk or opportunity for each feature. 
 
 11. Review the content. If Copilot added the risks and opportunities in a separate section rather than in each feature, ask it to remove the risk and opportunity section that it just added and instead add the risk or opportunity at the end of each feature rather than in a separate section of risks and opportunities. 
  
-12.	Review the new content. If you aren’t satisfied with how Copilot formatted any of the new content, then make any adjustments that you want.
+12. Review the new content. If you aren't satisfied with how Copilot formatted any of the new content, then make any adjustments that you want. Select **Done** when you finish editing the document.
 
 13. You plan to use this document in Task 3, so make note of the file name that appears above the menu bar.

--- a/Instructions/Labs/M03-empower-workforce-copilot-it/08-Ex2-2-use-viva-engage-draft-post.md
+++ b/Instructions/Labs/M03-empower-workforce-copilot-it/08-Ex2-2-use-viva-engage-draft-post.md
@@ -15,10 +15,7 @@ You then plan to post the announcement on a new community in Viva Engage. A comm
 
 Perform the following steps to complete this task:
 
-1. In the **Microsoft 365 Copilot Chat** window, select the **Apps** icon in the navigation pane. In the **Apps** menu that appears, select **All apps**. Under the top section of apps in the **Apps** window, select **All apps→**. In the **All apps** window, scroll down and select **Engage**.
-
-   > [!NOTE]
-   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Engage** from the list of apps that appears.
+1. In the **Microsoft 365 Copilot Chat** window, select the **App Launcher** (grid icon) in the top left corner of the page, and then select **More Apps**. In the **All apps→** window, scroll down and select **Engage**.
 
 2. In **Viva Engage**, you should begin by creating a new community for testing the Viva Engage announcement that you create later in this task. To do so, select **+ Create new** at the top of the **Engage** navigation pane, and then select **Community** in the drop-down menu that appears.
 

--- a/Instructions/Labs/M03-empower-workforce-copilot-it/08-Ex2-2-use-viva-engage-draft-post.md
+++ b/Instructions/Labs/M03-empower-workforce-copilot-it/08-Ex2-2-use-viva-engage-draft-post.md
@@ -15,31 +15,33 @@ You then plan to post the announcement on a new community in Viva Engage. A comm
 
 Perform the following steps to complete this task:
 
-1.  In the **Microsoft 365 Copilot Chat** window, select the **Apps** icon in the navigation pane. In the **Apps** menu that appears, select **All apps**. Under the top section of apps in the **Apps** window, select **All apps→**. In the **All apps** window, scroll down and select **Viva**.
+1. In the **Microsoft 365 Copilot Chat** window, select the **Apps** icon in the navigation pane. In the **Apps** menu that appears, select **All apps**. Under the top section of apps in the **Apps** window, select **All apps→**. In the **All apps** window, scroll down and select **Viva**.
 
-2.  In the **Viva for the web** window, select **Engage,** which appears in the navigation pane.
+   > [!NOTE]
+   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Engage** from the list of apps that appears.
 
-3.  In **Viva Engage**, you should begin by creating a new community for testing the Viva Engage announcement that you create later in this task. To do so, select **+Create new** at the top of the **Engage** navigation pane, and then select **Community** in the drop-down menu that appears.
+2. In **Viva Engage**, you should begin by creating a new community for testing the Viva Engage announcement that you create later in this task. To do so, select **+ Create new** at the top of the **Engage** navigation pane, and then select **Community** in the drop-down menu that appears.
 
-4.  In the **Create a new community** window, enter **Copilot testing** in the **Name** field.
+3. In the **Create a new community** window, enter **Copilot testing** in the **Name** field.
 
    > [!IMPORTANT]
    > Because you’re using your own Microsoft 365 tenant for this training exercise, any Viva Engage community you create is visible to other users in your tenant. To avoid confusion, use **Copilot testing** as the Community name instead of something like **Microsoft 365 feature rollout**, which could make it appear to be part of an actual initiative at your company.
 
-5.  Enter **This community is used for testing Copilot training content** in the **Description** field. Select the **Create** button.
+4. Enter `This community is used for testing Copilot training content` in the **Description** field. Select the **Create** button.
 
-6.  In **Viva Engage**, select **+Create new** at the top of the navigation pane, and then select **Post** in the drop-down menu that appears.
+5. In **Viva Engage**, select **+ Create new** at the top of the navigation pane, and then select **Post** in the drop-down menu that appears.
 
-7.  In the **Post** window, select the Copilot icon to open the Copilot pane.
+6. In the **Post** window, select the Copilot icon to open the Copilot pane.
 
-8.  In the prompt field, attach the Word document that you created in the prior task. Then ask Copilot to draft a Viva Engage announcement post for VanArsdel, Ltd. announcing the upcoming Microsoft 365 features that are identified in the attached document. The tone of the post should be friendly, concise, and helpful. Since its target audience is all VanArsdel employees, it shouldn't be overly technical. The post should include a short, attention-grabbing headline, the top three bullet highlights (what each feature does and how it helps them), a one-sentence call to action for employees to try the features or attend a short demo, a request for feedback with a link (placeholder) to a short survey, and suggested hashtags and an emoji or two.
+7. In the prompt field, attach the Word document that you created in the prior task. Then ask Copilot to draft a Viva Engage announcement post for VanArsdel, Ltd. announcing the upcoming Microsoft 365 features that are identified in the attached document. Since its target audience is all VanArsdel employees, it shouldn't be overly technical. The post should include a short, attention-grabbing headline, the top three bullet highlights (what each feature does and how it helps them), a one-sentence call to action for employees to try the features or attend a short demo, a request for feedback with a link (placeholder) to a short survey, and suggested hashtags and an emoji or two.
 
-9.  Review the generated content and select the **+Add to post** option that appears at the end of the results in the Copilot pane. Delete any extraneous Copilot chat text that appears in the post (usually at the start and end, such as “You asked for a…”).
+8. Review the generated content and select the **+ Add to post** option that appears at the end of the results in the Copilot pane. Delete any extraneous Copilot chat text that appears in the post (usually at the start and end, such as “You asked for a…”).
 
-10.  Before you can post this announcement, you must first select a community or storyline. However, because you created the **Copilot testing** community at the start of this task, and since that community was displayed in Viva Engage when you created this post, the announcement should appear at the bottom of the post window, above the menu bar. If this situation is what you see, then proceed to the next step.
-    <br/><br/> However, if a **Select a community or storyline** option appears at the bottom of the Viva Engage post instead, then select it and select the **Copilot testing** community from the menu that appears.
+9. Before you can post this announcement, you must first select a community or storyline. However, because you created the **Copilot testing** community at the start of this task, and since that community was displayed in Viva Engage when you created this post, the announcement should appear at the bottom of the post window, above the menu bar. If this situation is what you see, then proceed to the next step.
+    
+    However, if a **Select a community or storyline** option appears at the bottom of the Viva Engage post instead, then select it and select the **Copilot testing** community from the menu that appears.
 
-11.  Select the **Post** button.
+10. Select the **Post** button.
 
-12.  In the **Copilot testing** community, you should see the post that Copilot just created for you.
+11. In the **Copilot testing** community, you should see the post that Copilot just created for you.
 

--- a/Instructions/Labs/M03-empower-workforce-copilot-it/08-Ex2-2-use-viva-engage-draft-post.md
+++ b/Instructions/Labs/M03-empower-workforce-copilot-it/08-Ex2-2-use-viva-engage-draft-post.md
@@ -15,7 +15,7 @@ You then plan to post the announcement on a new community in Viva Engage. A comm
 
 Perform the following steps to complete this task:
 
-1. In the **Microsoft 365 Copilot Chat** window, select the **Apps** icon in the navigation pane. In the **Apps** menu that appears, select **All apps**. Under the top section of apps in the **Apps** window, select **All apps→**. In the **All apps** window, scroll down and select **Viva**.
+1. In the **Microsoft 365 Copilot Chat** window, select the **Apps** icon in the navigation pane. In the **Apps** menu that appears, select **All apps**. Under the top section of apps in the **Apps** window, select **All apps→**. In the **All apps** window, scroll down and select **Engage**.
 
    > [!NOTE]
    > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Engage** from the list of apps that appears.

--- a/Instructions/Labs/M03-empower-workforce-copilot-it/09-Ex2-3-use-chat-create-best-practice-tips.md
+++ b/Instructions/Labs/M03-empower-workforce-copilot-it/09-Ex2-3-use-chat-create-best-practice-tips.md
@@ -19,19 +19,19 @@ Rather than starting from scratch, you plan to ask Copilot Chat to generate thes
 
 Perform the following steps to complete this task:
 
-1.  In your Microsoft Edge browser, go to the **Microsoft 365** home page. Since the scenario involves implementing future features that are published by Microsoft and not stored in VanArsdel’s tenant, select the **Web** option rather than the **Work** option. Leave the response mode selector set to **Auto**.
+1. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page. Since the scenario involves implementing future features that are published by Microsoft and not stored in VanArsdel's tenant, select the **Web** option rather than the **Work** option. Leave the response mode selector set to **Auto**.
 
-2.  In the Copilot Chat prompt, attach the document from Task 1 that contains the Microsoft 365 feature list. Then ask Copilot to create a cheat sheet titled **10 Best Practice Tips**. It should include 10 concise best-practice tips for adopting the new Microsoft 365 features that are listed in the attached document. Each tip should include a short sentence that describes what the tip is, followed by a short explanation (maximum of 25 words) that describes why the tip is important to users. 
+2. In the Copilot Chat prompt, attach the document from Task 1 that contains the Microsoft 365 feature list. Then ask Copilot to create a cheat sheet titled **10 Best Practice Tips**. It should include 10 concise best-practice tips for adopting the new Microsoft 365 features that are listed in the attached document. Each tip should include a short sentence that describes what the tip is, followed by a short explanation (maximum of 25 words) that describes why the tip is important to users. 
 
-3.  Review the cheat sheet that Copilot generated. Submit any suggested Copilot prompts that interest you. For example, you might want to ask Copilot to add a poster-style visual. 
+3. Review the cheat sheet that Copilot generated. Submit any suggested Copilot prompts that interest you. For example, you might want to ask Copilot to add a poster-style visual. 
 
-4.  Ask Copilot to output the tips into the following formats:
+4. Ask Copilot to output the tips into the following formats:
     - Convert the list into a one-page cheat sheet (Word document) and a PDF.
     - Convert the list into a version for email (include a short subject line + 5 bullets).
 
-5.  Download the Word document and the PDF that Copilot generated. Open each file to review its contents.
+5. Download the Word document and the PDF that Copilot generated. Open each file to review its contents.
 
-6.	While you plan to use this material for educating frontline workers, it dawns on you that it might be best to create separate versions that are tailored for Executives, Sales, and IT. Ask Copilot to generate separate, persona-specific cheat sheets in PDF format for Executives, Sales, and IT.
+6. While you plan to use this material for educating frontline workers, it dawns on you that it might be best to create separate versions that are tailored for Executives, Sales, and IT. Ask Copilot to generate separate, persona-specific cheat sheets in PDF format for Executives, Sales, and IT.
 
-7.	Download each of the PDFs and review them. Note the differences between each persona’s document. 
+7. Download each of the PDFs and review them. Note the differences between each persona's document.
 

--- a/Instructions/Labs/M03-empower-workforce-copilot-it/10-Ex2-4-use-surveys-agent-capture-feedback.md
+++ b/Instructions/Labs/M03-empower-workforce-copilot-it/10-Ex2-4-use-surveys-agent-capture-feedback.md
@@ -29,10 +29,7 @@ Perform the following steps to complete this task:
 
 4. Once you're satisfied with the survey, copy the survey content.
 
-5. Your next step is to paste the copied survey into Microsoft Forms. In the **Microsoft 365 Copilot Chat** window, select the **Apps** icon in the navigation pane. In the **Apps** menu that appears, select **All apps**. Under the top section of apps in the **Apps** window, select **All apps→**. In the **All apps** window, select **Forms**.
-
-   > [!NOTE]
-   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Forms** from the list of apps that appears.
+5. Your next step is to paste the copied survey into Microsoft Forms. In the **Microsoft 365 Copilot Chat** window, select the **App Launcher** (grid icon) in the top left corner of the page, and then select **More Apps**. In the **All apps→** window, scroll down and select **Forms**.
 
 6. In the **Forms** window, create a new form. Paste in the copied survey in the **Draft with Copilot** window and submit your request.
 

--- a/Instructions/Labs/M03-empower-workforce-copilot-it/10-Ex2-4-use-surveys-agent-capture-feedback.md
+++ b/Instructions/Labs/M03-empower-workforce-copilot-it/10-Ex2-4-use-surveys-agent-capture-feedback.md
@@ -1,7 +1,7 @@
 ---
 lab:
   title: 'Exercise 2, Task 4: Use the Surveys agent to create a feedback survey'
-  description: You want to use the Surveys agent in Microsoft 365 Copilot to brainstorm and design this survey layout—including question types, structure, and branching logic. Your goal is to design an eight question survey (five scaled and three open-text) to capture meaningful feedback about users’ experience with the new features. Once you design the survey layout, you plan to copy and paste it into Microsoft Forms with the help of Copilot in Forms.
+  description: You want to use the Surveys agent in Microsoft 365 Copilot to brainstorm and design this survey layout—including question types, structure, and branching logic. Your goal is to design an eight question survey (five scaled and three open-text) to capture meaningful feedback about users' experience with the new features. Once you design the survey layout, you plan to copy and paste it into Microsoft Forms with the help of Copilot in Forms.
   duration: 26 minutes
   level: 200
   islab: true
@@ -12,28 +12,30 @@ lab:
 
 # Exercise 2, Task 4: Use the Surveys agent to create a feedback survey
 ---
-One month after the feature rollout, VanArsdel’s CIO wants to know how employees are responding. Are they trying the new features? Are they running into problems? To gather this data, IT plans to distribute a short internal survey to measure adoption and satisfaction.
+One month after the feature rollout, VanArsdel's CIO wants to know how employees are responding. Are they trying the new features? Are they running into problems? To gather this data, IT plans to distribute a short internal survey to measure adoption and satisfaction.
 
-You want to use the Surveys agent in Microsoft 365 Copilot to brainstorm and design this survey layout—including question types, structure, and branching logic. Your goal is to design an eight question survey (five scaled and three open-text) to capture meaningful feedback about users’ experience with the new features. Once you design the survey layout, you plan to copy and paste it into Microsoft Forms with the help of Copilot in Forms.
+You want to use the Surveys agent in Microsoft 365 Copilot to brainstorm and design this survey layout—including question types, structure, and branching logic. Your goal is to design an eight question survey (five scaled and three open-text) to capture meaningful feedback about users' experience with the new features. Once you design the survey layout, you plan to copy and paste it into Microsoft Forms with the help of Copilot in Forms.
 
 Perform the following steps to complete this task:
 
-1.  In the **Microsoft 365** home page, select **All agents**, then browse through the list of prebuilt agents and select the **Surveys** agent.
+1. In the **Microsoft 365 Copilot** home page, select **Agents**, then browse through the list of prebuilt agents and select the **Surveys** agent.
 
-2.  Ask the **Surveys** agent to create a new survey that captures feedback on VanArsdel’s employee experience with the new Microsoft 365 features (attach the document containing the features from Task 1). The survey should include the following features:
+2. Ask the **Surveys** agent to create a new survey that captures feedback on VanArsdel's employee experience with the new Microsoft 365 features (attach the document containing the features from Task 1). The survey should include the following features:
     - A one-sentence introduction
     - Eight questions: five of which should be quantitative (Likert scales, multiple choice) and three open-text questions
-    - Branching rules: If the employee answer "No" to any of the adoption questions, then ask a follow-up, open-text question in which they must explain why they didn’t adopt the feature.
+    - Branching rules: If the employee answers "No" to any of the adoption questions, then ask a follow-up, open-text question in which they must explain why they didn't adopt the feature.
 
-3.  Review the results. While it appears to be a good starting point, you feel that it can be improved with just some minor tweaks. Ask it to include one demographic question that asks what department they’re in. Also, if the Likert scale questions don't provide text for each 1-5 option, then have it add text for all options. For example, if 1 is **Very difficult** and 5 is **Very easy**, but 2-4 have no explanations, then have it provide an explanation for 2-4 as well. 
+3. Review the results. While it appears to be a good starting point, you feel that it can be improved with just some minor tweaks. Ask it to include one demographic question that asks what department they're in. Also, if the Likert scale questions don't provide text for each 1-5 option, then have it add text for all options. For example, if 1 is **Very difficult** and 5 is **Very easy**, but 2-4 have no explanations, then have it provide an explanation for 2-4 as well. 
 
-4.  Once you’re satisfied with the survey, select the Copilot icon to copy the response.
+4. Once you're satisfied with the survey, copy the survey content.
 
-5.  Your next step is to paste the copied survey into Microsoft Forms. In the **Microsoft 365 Copilot Chat** window, select the **Apps** icon in the navigation pane. In the **Apps** menu that appears, select **All apps**. Under the top section of apps in the **Apps** window, select **All apps→**. In the **All apps** window, select **Forms**.
+5. Your next step is to paste the copied survey into Microsoft Forms. In the **Microsoft 365 Copilot Chat** window, select the **Apps** icon in the navigation pane. In the **Apps** menu that appears, select **All apps**. Under the top section of apps in the **Apps** window, select **All apps→**. In the **All apps** window, select **Forms**.
 
-6.  In the **Forms** window, create a new form. Paste in the copied survey in the **Draft with Copilot** window and submit your request.
+   > [!NOTE]
+   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Forms** from the list of apps that appears.
 
-7.  Review the results. You’re currently in draft mode (1 of 1), so if you’re satisfied with the current draft, select the **Keep it** button. Or, you can request other changes from Copilot. Select **Keep it** on any subsequent draft that you’re satisfied with. Or, use the forward and backward arrows to go to a specific draft that you like and then keep that particular draft.
+6. In the **Forms** window, create a new form. Paste in the copied survey in the **Draft with Copilot** window and submit your request.
 
+7. Review the results. You're currently in draft mode (1 of 1), so if you're satisfied with the current draft, select the **Keep and continue with Copilot** button. Or, you can request other changes from Copilot. Select **Keep and continue with Copilot** on any subsequent draft that you're satisfied with. Or, use the forward and backward arrows to go to a specific draft that you like and then keep that particular draft.
 
-8.  Once Copilot keeps the draft that you selected, it might indicate that it has other suggestions for your form. View those suggestions. For each suggestion, you can view how it affects your form. For example, select the suggestion to modernize the form theme, and then select a theme. Note the change to the form. You can then either discard or keep the change.
+8. Once Copilot keeps the draft that you selected, it might indicate that it has other suggestions for your form. View those suggestions. For each suggestion, you can view how it affects your form. For example, select the suggestion to modernize the form theme, and then select a theme. Note the change to the form. You can then either discard or keep the change.

--- a/Instructions/Labs/M03-empower-workforce-copilot-it/11-Ex2-5-use-analyst-agent-survey-results.md
+++ b/Instructions/Labs/M03-empower-workforce-copilot-it/11-Ex2-5-use-analyst-agent-survey-results.md
@@ -12,7 +12,7 @@ lab:
 
 # Exercise 2, Task 5: Use the Analyst agent to analyze survey results
 ---
-The survey results are in, so you must now brief the leadership team on adoption progress, user sentiment, and recommended next steps. To do so, you must analyze the survey data and produce a summary highlighting what’s working and where users need help.
+The survey results are in, so you must now brief the leadership team on adoption progress, user sentiment, and recommended next steps. To do so, you must analyze the survey data and produce a summary highlighting what's working and where users need help.
 
 By using the Analyst agent in Microsoft 365 Copilot, you plan to uncover trends, visualize adoption metrics, and generate a concise summary report. Your goal is to analyze the survey data to produce three charts, a five-bullet executive summary, and a short list of recommended IT actions to improve adoption.
 
@@ -21,15 +21,15 @@ By using the Analyst agent in Microsoft 365 Copilot, you plan to uncover trends,
 
 Perform the following steps to complete this task:
 
-1.  Select the following link to download the [**VanArsdel M365 Survey Results.xlsx**](https://go.microsoft.com/fwlink/?linkid=2347528) file and then store it in your OneDrive account so that Copilot can access it from your tenant.
+1. Select the following link to download the [**VanArsdel M365 Survey Results.xlsx**](https://go.microsoft.com/fwlink/?linkid=2347528) file and then store it in your OneDrive account so that Copilot can access it from your tenant.
 
-2.  Open the **VanArsdel M365 Survey Results.xlsx** spreadsheet and review the results. You might have to expand each column width to see the full extent of the answers. Close the spreadsheet once you’re done. 
+2. Open the **VanArsdel M365 Survey Results.xlsx** spreadsheet and review the results. You might have to expand each column width to see the full extent of the answers. Close the spreadsheet once you're done.
 
-3.  Return to Copilot Chat. In the Microsoft 365 navigation pane, select the **Analyst** agent.
+3. Return to Copilot Chat. In the Microsoft 365 Copilot navigation pane, select the **Analyst** agent.
 
-4.  In the **Analyst** agent, attach the **VanArsdel M365 Survey Results.xlsx** spreadsheet.
+4. In the **Analyst** agent, attach the **VanArsdel M365 Survey Results.xlsx** spreadsheet.
 
-5.  Ask the **Analyst** agent to analyze the attached employee survey results and provide the following feedback:
+5. Ask the **Analyst** agent to analyze the attached employee survey results and provide the following feedback:
 
     - A five-bullet executive summary (top three positives, top two concerns)
 
@@ -39,20 +39,19 @@ Perform the following steps to complete this task:
 
     - Any statistically significant patterns (if present)
 
-6.  Review the results. If the Analyst agent offers any suggested prompts, feel free to select and submit them if they interest you.
+6. Review the results. If the Analyst agent offers any suggested prompts, feel free to select and submit them if they interest you.
 
-7.  Ask the Analyst agent if there are any correlations that can be drawn from the data.
+7. Ask the Analyst agent if there are any correlations that can be drawn from the data.
 
-8.  Review the response. If the Analyst agent offers any suggested prompts related to the correlations that it found, feel free to select and submit them if they interest you.
+8. Review the response. If the Analyst agent offers any suggested prompts related to the correlations that it found, feel free to select and submit them if they interest you.
 
-9. Since you’re one of the leaders from the IT department, you’re curious as to the responses from members of the IT department. Ask the Analyst agent to filter the data to show responses from only the IT department.
+9. Since you're one of the leaders from the IT department, you're curious as to the responses from members of the IT department. Ask the Analyst agent to filter the data to show responses from only the IT department.
 
-10.  Review the response. If the Analyst agent offers any suggested prompts related to the IT responses, feel free to select and submit them if they interest you.
+10. Review the response. If the Analyst agent offers any suggested prompts related to the IT responses, feel free to select and submit them if they interest you.
 
 11. Finally, ask the Analyst agent to produce a one-page executive summary report for download, along with a polished executive slide deck that contains all these insights and charts for leadership review.
 
-12.  If the Analyst agent offers any suggested prompts related to these downloads, feel free to select and submit them if you wish.
+12. If the Analyst agent offers any suggested prompts related to these downloads, feel free to select and submit them if you wish.
 
-
-13.  Download the summary report and the slide deck and review each document.
+13. Download the summary report and the slide deck and review each document.
 


### PR DESCRIPTION
## Summary

This PR updates the **M03 (Empower your workforce with Microsoft 365 Copilot for IT)** lab instructions to match the current Microsoft 365 Copilot user interface and to apply Microsoft Learn style conventions. Changes correct UI drift in app navigation and Copilot pane steps, straighten curly quotes and apostrophes, normalize list numbering and spacing, and fix typos and grammar throughout the module.

## Changes

### Module-wide style normalization
- Replaced smart/curly quotes and apostrophes with straight equivalents across the module.
- Normalized ordered-list numbering and indentation, and removed stray `<br/>` spacing.
- Normalized inconsistent line endings in several files.
- Corrected `VanArsel` → `VanArsdel` product/company name typos and other grammar fixes.

### Exercise 1
- **Task 1 (Word):** Updated the Copilot pane steps to match the current Word UI (open Copilot from the bottom-right icon, confirm **Allow editing** mode, select **Done** when finished).
- **Task 2 (Whiteboard):** Updated steps for current Whiteboard UI, added **New Whiteboard** and welcome-message guidance, added an App Launcher fallback note, refreshed dialog names (**Categorize selected notes?**), and added the **Keep it** confirmation step.
- **Task 3 (PowerPoint):** Updated steps to open the Copilot pane from the bottom-right icon, set the mode to **Allow editing**, and clarified slide-insertion prompts; added an App Launcher fallback note and grammar fixes.

### Exercise 2
- **Intro:** Fixed `VanArsel` → `VanArsdel` typo and removed a stray trailing character.
- **Task 1 (Copilot Chat):** Updated to **Microsoft 365 Copilot** home page naming, clarified Work vs. Web mode behavior, updated **Edit in Pages** access (via ellipsis), and refreshed Word Copilot edit-mode steps.
- **Task 2 (Viva Engage):** Updated app navigation from **Viva** to **Engage**, added an App Launcher fallback note, and refined the **+ Create new** and post steps.
- **Task 3 (best-practice tips):** Updated home page naming and normalized list numbering.
- **Task 4 (Surveys agent):** Normalized list numbering, spacing, and quotes.
- **Task 5 (Analyst agent):** Corrected the navigation pane name to **Microsoft 365 Copilot**, fixed spacing, and replaced a stray quote character.

## Files changed

- `Instructions/Labs/M03-empower-workforce-copilot-it/01-introduction.md` — quote/line-ending normalization and grammar fixes
- `Instructions/Labs/M03-empower-workforce-copilot-it/02-Ex1-introduction-project-planning-exercise.md` — straightened apostrophes and fixed spacing
- `Instructions/Labs/M03-empower-workforce-copilot-it/03-Ex1-1-use-chat-define-project-framework.md` — updated Copilot pane steps for current UI
- `Instructions/Labs/M03-empower-workforce-copilot-it/04-Ex1-2-use-whiteboard-identify-risks.md` — refreshed Whiteboard UI steps, dialogs, and added confirmation/fallback notes
- `Instructions/Labs/M03-empower-workforce-copilot-it/05-Ex1-3-use-powerpoint-create-presentation.md` — updated Copilot pane and editing-mode steps, grammar fixes
- `Instructions/Labs/M03-empower-workforce-copilot-it/06-Ex2-introduction-transform-adoption-exercise.md` — fixed VanArsdel typo, quotes, and line endings
- `Instructions/Labs/M03-empower-workforce-copilot-it/07-Ex2-1-use-chat-identify-upcoming-features.md` — updated home page naming, Work/Web mode text, and Pages/Word steps
- `Instructions/Labs/M03-empower-workforce-copilot-it/08-Ex2-2-use-viva-engage-draft-post.md` — updated Viva/Engage navigation and post steps, added fallback note
- `Instructions/Labs/M03-empower-workforce-copilot-it/09-Ex2-3-use-chat-create-best-practice-tips.md` — updated home page naming and list numbering
- `Instructions/Labs/M03-empower-workforce-copilot-it/10-Ex2-4-use-surveys-agent-capture-feedback.md` — normalized numbering, spacing, and quotes
- `Instructions/Labs/M03-empower-workforce-copilot-it/11-Ex2-5-use-analyst-agent-survey-results.md` — corrected navigation pane name and spacing
