### PR TITLE
Fix folder(M06): apply Microsoft Learn style and fix UI drift in HR labs

### DIFF
--- a/Instructions/Labs/M06-empower-workforce-copilot-hr/01-introduction.md
+++ b/Instructions/Labs/M06-empower-workforce-copilot-hr/01-introduction.md
@@ -33,12 +33,9 @@ Follow the steps below to upload all files needed to **OneDrive**:
 
 7. If prompted to **Stay signed in**, select **Don't show this again** and then **Yes**.
 
-8. In **Microsoft 365 Copilot**, select **Apps**.
+8. In **Microsoft 365 Copilot**, select the **App Launcher** (grid icon), and then select **More Apps**.
 
 9. Within **Apps**, select **OneDrive**.
-
-   > [!NOTE]
-   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **OneDrive** from the list of apps that appears.
 
 10. In **OneDrive**, in the top-left corner, select **+ Create or upload** > **Files upload**.
 

--- a/Instructions/Labs/M06-empower-workforce-copilot-hr/01-introduction.md
+++ b/Instructions/Labs/M06-empower-workforce-copilot-hr/01-introduction.md
@@ -12,7 +12,7 @@ lab:
 
 # Lab Setup:
 
-In this module, we'll create prompts for Microsoft 365 Copilot that reference files. First, let’s upload all required files to OneDrive to ensure they're accessible throughout the lab.
+In this module, we'll create prompts for Microsoft 365 Copilot that reference files. First, let's upload all required files to OneDrive to ensure they're accessible throughout the lab.
 
 
 ### Uploading Files to OneDrive
@@ -20,23 +20,39 @@ In this module, we'll create prompts for Microsoft 365 Copilot that reference fi
 Follow the steps below to upload all files needed to **OneDrive**:
 
 1. Log into the virtual machine provided by your tenant provider as the local **Administrator** account with the password `Pa55w.rd`.
+
 2. In the Windows taskbar, select **Microsoft Edge**.
+
 3. In the address bar, enter `https://www.office.com`.
-4. Under **Welcome to Microsoft 365**, select **Sign in**.
-5. At the **Sign-in prompt**, enter `userx@yourtenant.onmicrosoft.com` (username and tenant provided by your tenant provided) and select **Next**.
-6. At the **Enter password** screen, enter the password (provided by tenant provider) for the User account, then select **Sign in**.
+
+4. On the Microsoft 365 Copilot landing page, select **Sign in**.
+
+5. At the **Sign-in prompt**, enter `userx@yourtenant.onmicrosoft.com` (username and tenant provided by your tenant provider) and select **Next**.
+
+6. At the **Enter password** screen, enter the password (provided by your tenant provider) for the User account, then select **Sign in**.
+
 7. If prompted to **Stay signed in**, select **Don't show this again** and then **Yes**.
-8. In **Microsoft 365**, select **Apps**.
+
+8. In **Microsoft 365 Copilot**, select **Apps**.
+
 9. Within **Apps**, select **OneDrive**.
-10. In **OneDrive**, in the top-left corner, select **+** (add new) > **File upload**.
+
+   > [!NOTE]
+   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **OneDrive** from the list of apps that appears.
+
+10. In **OneDrive**, in the top-left corner, select **+ Create or upload** > **Files upload**.
+
 11. In **File Explorer**, select **This PC** > **Local Disk (C:)** and open the **ResourceFiles** folder.
+
 12. Select all files within the **ResourceFiles** folder, then select **Open** to upload them to **OneDrive**.
-13. When the upload is complete, you should see **Uploaded 29 items to My files** in the bottom center of the screen.
+
+13. When the upload is complete, you should see **Uploaded 92 items to My files** in the bottom center of the screen.
+
 14. Leave **Edge** open and move on to the next task.
 
 ### Referencing Files in Copilot
 
-When using Copilot, you may find that some files aren’t immediately available in the suggestions. This occurs because certain Copilot experiences only reference files from the **Most Recently Used (MRU)** list, while others let you browse **OneDrive** directly. To ensure a file appears in the **MRU** list, simply open it in the relevant Microsoft 365 app, and it will be added automatically.
+When using Copilot, you may find that some files aren't immediately available in the suggestions. This occurs because certain Copilot experiences only reference files from the **Most Recently Used (MRU)** list, while others let you browse **OneDrive** directly. To ensure a file appears in the **MRU** list, open it in the relevant Microsoft 365 app, and it's added automatically.
 
 > [!IMPORTANT]
 > Microsoft 365 Copilot can only work with files saved to **OneDrive**. Files stored locally on your PC will need to be moved to **OneDrive** for Copilot to access them.
@@ -47,17 +63,17 @@ Human Resources (HR) departments are at the heart of every organization, respons
 
 Copilot can help HR departments in numerous ways, including:
 
-- **Automating routine tasks**. Copilot can handle repetitive HR inquiries, such as questions about benefits, leave policies, promotions, and relocation. By integrating Copilot with your organization’s HR documents and systems, employees receive instant, accurate answers—reducing the workload on HR staff and improving service quality.
+- **Automating routine tasks**. Copilot can handle repetitive HR inquiries, such as questions about benefits, leave policies, promotions, and relocation. By integrating Copilot with your organization's HR documents and systems, employees receive instant, accurate answers—reducing the workload on HR staff and improving service quality.
 
 - **Enhancing data-driven insights**. HR professionals can use Copilot to analyze workforce data, identify trends in engagement and attrition, and generate actionable reports. Copilot in Excel, for example, can summarize manager performance metrics, visualize team health, and uncover patterns that inform coaching and development strategies.
 
-- **Supporting strategic communication**. Copilot assists HR teams in drafting clear, professional communications—whether it’s summarizing survey results, preparing feedback for managers, or composing policy updates. Copilot ensures consistency and saves valuable time by automating the creation of emails and reports. 
+- **Supporting strategic communication**. Copilot assists HR teams in drafting clear, professional communications—whether it's summarizing survey results, preparing feedback for managers, or composing policy updates. Copilot ensures consistency and saves valuable time by automating the creation of emails and reports.
 
 - **Empowering employee self-service**. Custom Copilot agents enable employees to access HR information on their own, from policy details to relocation support. This self-service approach fosters transparency, empowers employees, and allows HR teams to focus on higher-value work.
 
 - **Connecting internal and external knowledge**. Copilot can synthesize information from both company data and web sources. For example, employees relocating to a new city can use Copilot to research local schools, housing, and amenities—combining internal policies with external insights for holistic support.
 
-This training module guides you through the following practical exercises that demonstrate Copilot’s effect on HR operations:
+This training module guides you through the following practical exercises that demonstrate Copilot's effect on HR operations:
 
 - **Delivering manager insights**. Learn how Copilot in Excel helps HR analyze manager performance, identify strengths and opportunities, and communicate findings to leadership.
 
@@ -69,13 +85,12 @@ By the end of this module, you should clearly see how Copilot can transform HR w
 
 One of the primary keys to effectively using Copilot is the quality of your Copilot prompts. A good Copilot prompt is built around the following four key elements that make your request clear, actionable, and tailored for the best results:
 
-- **Goal**. Clearly state what you want Copilot to do. For example: “Generate three to five bullet points summarizing the latest project updates.”
+- **Goal**. Clearly state what you want Copilot to do. For example: "Generate three to five bullet points summarizing the latest project updates."
 
-- **Context**. Provide background information so Copilot understands why you need this request and who or what is involved. For example: “Prepare these bullet points for a meeting with Client X about their ‘Phase 3+’ brand campaign.”
+- **Context**. Provide background information so Copilot understands why you need this request and who or what is involved. For example: "Prepare these bullet points for a meeting with Client X about their 'Phase 3+' brand campaign."
 
-- **Sources**. Specify where Copilot should look for information (documents, emails, Teams chats, and so on). For example: “Focus on emails and Teams chats since June.”
+- **Sources**. Specify where Copilot should look for information (documents, emails, Teams chats, and so on). For example: "Focus on emails and Teams chats since June."
 
-- **Expectations**. Define how you want the response delivered—tone, style, or level of detail. For example: “Use simple language so I can get up to speed quickly” or “Explain it as if I were a pirate.”
+- **Expectations**. Define how you want the response delivered—tone, style, or level of detail. For example: "Use simple language so I can get up to speed quickly" or "Explain it as if I were a pirate."
 
-
-Keep these four elements front and center as you practice creating prompts—they’re the foundation for getting clear, accurate, and useful results from Copilot. Implementing these elements as you write prompts in these exercises can build real-world skills, so writing effective prompts becomes second nature.
+Keep these four elements front and center as you practice creating prompts—they're the foundation for getting clear, accurate, and useful results from Copilot. Implementing these elements as you write prompts in these exercises can build real-world skills, so writing effective prompts becomes second nature.

--- a/Instructions/Labs/M06-empower-workforce-copilot-hr/02-Ex1-introduction-manager-insights-exercise.md
+++ b/Instructions/Labs/M06-empower-workforce-copilot-hr/02-Ex1-introduction-manager-insights-exercise.md
@@ -37,12 +37,11 @@ This exercise shows Copilot enables HR professionals to move from reporting metr
 
 ### Scenario
 
-You’re an HR Analyst at Contoso Ltd., a global technology company with 8,000 employees. In recent years, Contoso made manager effectiveness a top strategic priority, recognizing that strong leadership directly impacts employee engagement, retention, and overall business performance. However, the company’s annual employee engagement survey revealed significant disparities across departments. Some teams are thriving under exceptional management, while others are experiencing disengagement, higher attrition, and stagnating performance.
+You're an HR Analyst at Contoso Ltd., a global technology company with 8,000 employees. In recent years, Contoso made manager effectiveness a top strategic priority, recognizing that strong leadership directly impacts employee engagement, retention, and overall business performance. However, the company's annual employee engagement survey revealed significant disparities across departments. Some teams are thriving under exceptional management, while others are experiencing disengagement, higher attrition, and stagnating performance.
 
-Contoso’s executive leadership, led by the Chief People Officer, is committed to building a culture of accountability and continuous improvement among its managers. To achieve this goal, HR is tasked with implementing a robust, data-driven approach to monitoring manager performance. 
+Contoso's executive leadership, led by the Chief People Officer, is committed to building a culture of accountability and continuous improvement among its managers. To achieve this goal, HR is tasked with implementing a robust, data-driven approach to monitoring manager performance.
 
 This initiative is designed to ensure that every manager receives clear, actionable feedback and has a tailored development plan. By utilizing Microsoft 365 Copilot, HR aims to move beyond traditional reporting and deliver deep, actionable insights that empower leaders to make informed decisions, address challenges proactively, and foster a high-performing, engaged workforce.
 
-Your task is to use Microsoft 365 Copilot to extract insights from manager-level HR data, summarize findings, and communicate targeted recommendations to managers and HR leadership. The insights you generate play a critical role in shaping Contoso’s management culture and driving organizational success.
-
+Your task is to use Microsoft 365 Copilot to extract insights from manager-level HR data, summarize findings, and communicate targeted recommendations to managers and HR leadership. The insights you generate play a critical role in shaping Contoso's management culture and driving organizational success.
 

--- a/Instructions/Labs/M06-empower-workforce-copilot-hr/03-Ex1-1-use-excel-identify-manager-metrics.md
+++ b/Instructions/Labs/M06-empower-workforce-copilot-hr/03-Ex1-1-use-excel-identify-manager-metrics.md
@@ -44,10 +44,7 @@ Perform the following steps to complete this task:
 
 1. Select the following link to download [**Contoso_HR_ManagerMetrics.xlsx**](https://go.microsoft.com/fwlink/?linkid=2347518) and then store it in your OneDrive account.
 
-2. In your Microsoft Edge browser, sign in to the **Microsoft 365 Copilot** home page [**https://www.microsoft365.com**](https://www.microsoft365.com), select **Apps** in the navigation pane, and then select **Excel** from the **Apps** menu.
-
-   > [!NOTE]
-   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Excel** from the list of apps that appears.
+2. In your Microsoft Edge browser, sign in to the **Microsoft 365 Copilot** home page [**https://www.microsoft365.com**](https://www.microsoft365.com), select the **App Launcher** (grid icon), and then select **More Apps**. From the list of apps, select **Excel**.
 
 3. In **Excel for the web**, select **Upload a file**, and then open the **Contoso_HR_ManagerMetrics.xlsx** file that you downloaded in Step 1.
 

--- a/Instructions/Labs/M06-empower-workforce-copilot-hr/03-Ex1-1-use-excel-identify-manager-metrics.md
+++ b/Instructions/Labs/M06-empower-workforce-copilot-hr/03-Ex1-1-use-excel-identify-manager-metrics.md
@@ -24,53 +24,56 @@ These key HR metrics are stored in the file titled **Contoso_HR_ManagerMetrics.x
 
 #### Using Copilot in Excel
 
-Excel provides two ways to use Copilot: standard Copilot prompts for asking questions and getting insights about the data in the workbook, and **Edit with Copilot** in the Copilot pane for making direct, in‑place changes to worksheets, tables, and formulas.
+Excel provides two ways to use Copilot: standard Copilot prompts for asking questions and getting insights about the data in the workbook, and **Edit with Copilot** in the Copilot pane for making direct, in-place changes to worksheets, tables, and formulas.
 
-- You should use Copilot’s standard prompts in Excel for quick questions, simple summaries, or one‑off insights about the data you’re already viewing. When using the Copilot pane, if you enter a prompt without selecting **Edit with Copilot**, Copilot responds in a chat‑style mode that generates suggestions or content separately, rather than making direct, in‑place changes to the workbook.  
+- You should use Copilot's standard prompts in Excel for quick questions, simple summaries, or one-off insights about the data you're already viewing. When using the Copilot pane, if you enter a prompt without selecting **Edit with Copilot**, Copilot responds in a chat-style mode that generates suggestions or content separately, rather than making direct, in-place changes to the workbook.
     
-- You should use **Edit with Copilot** when you want Copilot to work directly with the worksheet—such as cleaning data, adding formulas, restructuring tables, or making iterative, in‑place changes. **Edit with Copilot** is designed for hands‑on data work, so it understands the structure of the sheet and can apply changes directly, rather than just describing what you could do.
+- You should use **Edit with Copilot** when you want Copilot to work directly with the worksheet—such as cleaning data, adding formulas, restructuring tables, or making iterative, in-place changes. **Edit with Copilot** is designed for hands-on data work, so it understands the structure of the sheet and can apply changes directly, rather than just describing what you could do.
 
-In summary, use chat‑style Copilot for thinking and generating ideas; use **Edit with Copilot** for hands‑on editing inside the file. **Edit with Copilot** proposes specific changes (formulas, columns, cleanup steps) and, once you confirm, it applies those changes directly to the worksheet rather than expecting the user to explicitly apply them through copy and paste.  
+In summary, use chat-style Copilot for thinking and generating ideas; use **Edit with Copilot** for hands-on editing inside the file. **Edit with Copilot** proposes specific changes (formulas, columns, cleanup steps) and, once you confirm, it applies those changes directly to the worksheet rather than expecting the user to explicitly apply them through copy and paste.
 
 This task uses the **Edit with Copilot** functionality.
 
 In addition, Copilot for Excel provides a response control selector that lets you choose which AI model Copilot uses to work with your workbook. You can leave this set to **Auto** (the default option) and let Copilot select a model for you, or choose a specific model when you want to influence how Copilot approaches the task.
 
-If you’ve used Copilot Chat, you know that it also includes a response control selector. However, its options are different from the Excel selector. In Copilot Chat, the selector controls how deeply Copilot reasons about your request. In Excel, the selector controls which AI model performs the work. Although these selectors might appear to be similar, they control different aspects of Copilot and aren't the same setting.
+If you've used Copilot Chat, you know that it also includes a response control selector. However, its options are different from the Excel selector. In Copilot Chat, the selector controls how deeply Copilot reasons about your request. In Excel, the selector controls which AI model performs the work. Although these selectors might appear to be similar, they control different aspects of Copilot and aren't the same setting.
 
 This task uses the default **Auto** selector mode.
 
 Perform the following steps to complete this task:
 
-1.  Select the following link to download [**Contoso_HR_ManagerMetrics.xlsx**](https://go.microsoft.com/fwlink/?linkid=2347518) and then store it in your OneDrive account.
+1. Select the following link to download [**Contoso_HR_ManagerMetrics.xlsx**](https://go.microsoft.com/fwlink/?linkid=2347518) and then store it in your OneDrive account.
 
-2.  In your Microsoft Edge browser, sign in to the **Microsoft 365** home page **(https://www.microsoft365.com)**, select **Apps** in the navigation pane, and then select **Excel** from the **Apps** menu.
+2. In your Microsoft Edge browser, sign in to the **Microsoft 365 Copilot** home page [**https://www.microsoft365.com**](https://www.microsoft365.com), select **Apps** in the navigation pane, and then select **Excel** from the **Apps** menu.
 
-3.  In **Excel for the web**, select **Upload a file**, and then open the **Contoso_HR_ManagerMetrics.xlsx** file that you downloaded in Step 1.
+   > [!NOTE]
+   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Excel** from the list of apps that appears.
 
-4.  On the **Home** tab ribbon, select **Copilot**. In the Copilot pane, leave the response mode selector set to **Auto**. Then verify the **Edit with Copilot** icon appears in the prompt field next to the plus (+) sign. If you don’t see it, select the plus sign and then select **Edit with Copilot** in the drop-down menu. The icon should now appear in the prompt field. 
+3. In **Excel for the web**, select **Upload a file**, and then open the **Contoso_HR_ManagerMetrics.xlsx** file that you downloaded in Step 1.
+
+4. In the bottom-right corner of the Excel window, select the **Copilot** icon to open the Copilot pane. Verify the pane opens in edit mode—the heading should read **Let's edit your document**, and the prompt field should display the placeholder text **Describe what you'd like to edit**. Below the heading, confirm that the mode selector is set to **Allow editing** (so Copilot can edit your document directly). If it shows **Chat only**, select the drop-down and then select **Allow editing**.
 
 5. In the Copilot pane, ask Copilot in Excel to summarize this dataset and highlight which metrics most strongly indicate manager effectiveness.
 
-  > [!NOTE]
-  > For this first prompt, we’ve provided the text so you can see what an effective prompt looks like when it incorporates the four key elements discussed in the Introduction unit. You must write all remaining prompts in this exercise, but in doing so, you can use this prompt as a model to emulate._
+   > [!NOTE]
+   > For this first prompt, we've provided the text so you can see what an effective prompt looks like when it incorporates the four key elements discussed in the Introduction unit. You must write all remaining prompts in this exercise, but in doing so, you can use this prompt as a model to emulate.
 
-  **Summarize the dataset in Contoso_HR_ManagerMetrics.xlsx and identify which HR metrics most strongly indicate manager effectiveness. This task is part of an HR review at Contoso to evaluate manager strengths and development opportunities, such as high attrition or low training completion. Use the columns provided in the file (Engagement Score, Attrition Rate, Training Completion, Average Team Tenure, Internal Promotions, Performance Rating). Present the results in a clear, concise table with actionable insights that can be included in a report.**
+   **Summarize the dataset in Contoso_HR_ManagerMetrics.xlsx and identify which HR metrics most strongly indicate manager effectiveness. This task is part of an HR review at Contoso to evaluate manager strengths and development opportunities, such as high attrition or low training completion. Use the columns provided in the file (Engagement Score, Attrition Rate, Training Completion, Average Team Tenure, Internal Promotions, Performance Rating). Present the results in a clear, concise table with actionable insights that can be included in a report.**
 
-6.  Review the results in the new sheet.
+6. Review the results in the new sheet.
 
-7.  When working in Excel, you must always be on the workbook that you’re requesting Copilot to use. In this case, select **Sheet1** since you want Copilot to continue working with the spreadsheet data. Next, you want Copilot to identify trends in the data, so ask Copilot to identify managers with engagement scores below 70% and attrition rates above 15%, and present the results in a new sheet.
+7. When working in Excel, you must always be on the workbook that you're requesting Copilot to use. In this case, select **Sheet1** since you want Copilot to continue working with the spreadsheet data. Next, you want Copilot to identify trends in the data, so ask Copilot to identify managers with engagement scores below 70% and attrition rates above 15%, and present the results in a new sheet.
 
-8.  Review the results. You now want Copilot to create a visualization for this new sheet, so remain in the sheet and place your cursor after the last line of information. This cell is where you want Copilot to insert the visualization. Then ask Copilot to provide a visualization of the managers with engagement scores below 70% and attrition rates above 15%.
+8. Review the results. You now want Copilot to create a visualization for this new sheet, so remain in the sheet and place your cursor after the last line of information. This cell is where you want Copilot to insert the visualization. Then ask Copilot to provide a visualization of the managers with engagement scores below 70% and attrition rates above 15%.
 
-9.  Review the results and then return to **Sheet1**. You want to refine your exploration with correlation prompts. Ask Copilot to determine if there are any patterns between training completion and performance ratings, and then present the results in a new sheet.
+9. Review the results and then return to **Sheet1**. You want to refine your exploration with correlation prompts. Ask Copilot to determine if there are any patterns between training completion and performance ratings, and then present the results in a new sheet.
 
-10.  Review the results and then return to **Sheet1**. Now ask Copilot to create a table that ranks managers by overall team health. It should consider engagement, attrition, and training, and then present the results in a new sheet.  
+10. Review the results and then return to **Sheet1**. Now ask Copilot to create a table that ranks managers by overall team health. It should consider engagement, attrition, and training, and then present the results in a new sheet.
 
 11. Review the results and then return to **Sheet1**. You now want to visualize the relationship between attrition rate and engagement score. Ask Copilot to create a bar chart that shows attrition rate versus engagement score by department, and then present the results in a new sheet.
 
-12.  Review the results.
+12. Review the results.
 
-13.  Keep the tab open in your Microsoft Edge browser containing the **Contoso_HR_ManagerMetrics.xlsx** file for the next task.
+13. Keep the tab open in your Microsoft Edge browser containing the **Contoso_HR_ManagerMetrics.xlsx** file for the next task.
 
 At the end of this task, you should have a summarized view of manager performance and engagement across Contoso, including key indicators of team health. This dataset serves as the foundation for deeper analysis in Task 2, where you use Copilot to generate insights and produce individual manager reports.

--- a/Instructions/Labs/M06-empower-workforce-copilot-hr/03-Ex1-1-use-excel-identify-manager-metrics.md
+++ b/Instructions/Labs/M06-empower-workforce-copilot-hr/03-Ex1-1-use-excel-identify-manager-metrics.md
@@ -44,7 +44,7 @@ Perform the following steps to complete this task:
 
 1. Select the following link to download [**Contoso_HR_ManagerMetrics.xlsx**](https://go.microsoft.com/fwlink/?linkid=2347518) and then store it in your OneDrive account.
 
-2. In your Microsoft Edge browser, sign in to the **Microsoft 365 Copilot** home page [**https://www.microsoft365.com**](https://www.microsoft365.com), select **Apps** in the navigation pane, and then select **Excel** from the **Apps** menu.
+2. In your Microsoft Edge browser, sign in to the **Microsoft 365 Copilot** home page [**https://m365.cloud.microsoft.com**](https://m365.cloud.microsoft.com), select **Apps** in the navigation pane, and then select **Excel** from the **Apps** menu.
 
    > [!NOTE]
    > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Excel** from the list of apps that appears.

--- a/Instructions/Labs/M06-empower-workforce-copilot-hr/04-Ex1-2-use-excel-generate-manager-report.md
+++ b/Instructions/Labs/M06-empower-workforce-copilot-hr/04-Ex1-2-use-excel-generate-manager-report.md
@@ -13,16 +13,16 @@ You analyzed the **Contoso_HR_ManagerMetrics.xlsx** spreadsheet in Task 1 and id
 
 Perform the following steps to complete this task:
 
-1.  The **Contoso_HR_ManagerMetrics.xlsx** file that you updated in Task 1 should still be open in **Excel for the web**. If the file is still open, then select the **Starts a new chat** icon at the top of the Copilot pane to start a new chat. If you closed the file at the end of the previous task, then open it again along with the Copilot pane.
+1. The **Contoso_HR_ManagerMetrics.xlsx** file that you updated in Task 1 should still be open in **Excel for the web**. If the file is still open, then select the **Starts a new chat** icon at the top of the Copilot pane to start a new chat. If you closed the file at the end of the previous task, then open it again along with the Copilot pane.
 
-2.  Select **Sheet1** if necessary. In the Copilot pane, prompt Copilot to analyze the manager performance data and provide recommendations for improvement. Identify which managers are performing well versus those with opportunities for development. Also ask Copilot to summarize each manager’s top three strengths and areas for improvement. Display the results in a new sheet.
+2. Select **Sheet1** if necessary. In the Copilot pane, prompt Copilot to analyze the manager performance data and provide recommendations for improvement. Identify which managers are performing well versus those with opportunities for development. Also ask Copilot to summarize each manager's top three strengths and areas for improvement. Display the results in a new sheet.
 
-3.  Review the results. Remain in this sheet and then ask Copilot to create a new sheet that highlights the metrics that most strongly correlate with high team performance.
+3. Review the results. Remain in this sheet and then ask Copilot to create a new sheet that highlights the metrics that most strongly correlate with high team performance.
 
-4.  Review the results and then return to the manager performance sheet that Copilot created in Step 2. Ask Copilot to create a new sheet that highlights patterns between training and attrition rates. It should identify any managers whose low training completion might be contributing to higher attrition.
+4. Review the results and then return to the manager performance sheet that Copilot created in Step 2. Ask Copilot to create a new sheet that highlights patterns between training and attrition rates. It should identify any managers whose low training completion might be contributing to higher attrition.
 
-5.  Review the results and then return to the manager performance sheet that Copilot created in Step 2. You now want to export this sheet as a PDF file that you can email to leadership in Task 3 and use in your planning session in Task 4. To export this data sheet, select **File > Export > Download as PDF** (or it might say **Create PDF/XPS Document)**.  
+5. Review the results and then return to the manager performance sheet that Copilot created in Step 2. You now want to export this sheet as a PDF file that you can email to leadership in Task 3 and use in your planning session in Task 4. To export this data sheet, select **File > Export > Download as PDF** (or it might say **Create PDF/XPS Document**).
 
-    - If you selected **Download as PDF** in your version of Excel, Copilot displays the PDF in the existing tab in your Microsoft Edge browser. In the **Export** pane that appears, select the **Download** button. Copilot downloads a PDF file containing the table from the Manager Performance sheet. The file is stored in your PC’s **Downloads** folder. Copy this file from the **Downloads** folder to your OneDrive.  
-        
+    - If you selected **Download as PDF** in your version of Excel, Copilot displays the PDF in the existing tab in your Microsoft Edge browser. In the **Export** pane that appears, select the **Download** button. Copilot downloads a PDF file containing the table from the Manager Performance sheet. The file is stored in your PC's **Downloads** folder. Copy this file from the **Downloads** folder to your OneDrive.
+
     - If you selected **Create PDF/XPS Document** in your version of Excel, Copilot opens a **File Explorer** window. Save the file to your OneDrive.

--- a/Instructions/Labs/M06-empower-workforce-copilot-hr/05-Ex1-3-use-outlook-communicate-findings.md
+++ b/Instructions/Labs/M06-empower-workforce-copilot-hr/05-Ex1-3-use-outlook-communicate-findings.md
@@ -13,10 +13,7 @@ The Manager Performance report that you created in the prior task analyzes data 
 
 Perform the following steps to complete this task:
 
-1. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page, select **Apps** in the navigation pane, and then select **Outlook** from the **Apps** menu.
-
-   > [!NOTE]
-   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Outlook** from the list of apps that appears.
+1. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page, select the **App Launcher** (grid icon), and then select **More Apps**. From the list of apps, select **Outlook**.
 
 2. In **Outlook on the web**, select **New mail** to create a new email and attach the Manager Performance file that you stored on your OneDrive at the end of the prior task.
 

--- a/Instructions/Labs/M06-empower-workforce-copilot-hr/05-Ex1-3-use-outlook-communicate-findings.md
+++ b/Instructions/Labs/M06-empower-workforce-copilot-hr/05-Ex1-3-use-outlook-communicate-findings.md
@@ -9,56 +9,60 @@ lab:
 
 # Exercise 1, Task 3: Use Copilot in Outlook to communicate findings to HR leadership
 ---
-The Manager Performance report that you created in the prior task analyzes data from the **Contoso_HR_ManagerMetrics.xlsx** file and identifies each manager’s top 3 strengths and recommended areas for improvement. Your goal is to communicate these findings to the HR senior leadership team in a clear and professional manner, helping them understand strengths, opportunities, and actionable steps for development.
+The Manager Performance report that you created in the prior task analyzes data from the **Contoso_HR_ManagerMetrics.xlsx** file and identifies each manager's top 3 strengths and recommended areas for improvement. Your goal is to communicate these findings to the HR senior leadership team in a clear and professional manner, helping them understand strengths, opportunities, and actionable steps for development.
 
 Perform the following steps to complete this task:
 
-1.  In your Microsoft Edge browser, go to the **Microsoft 365** home page, select **Apps** in the navigation pane, and then select **Outlook** from the **Apps** menu.
+1. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page, select **Apps** in the navigation pane, and then select **Outlook** from the **Apps** menu.
 
-2.  In **Outlook on the web**, create a new email and attach the Manager Performance file that you stored on your OneDrive at the end of the prior task.
+   > [!NOTE]
+   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Outlook** from the list of apps that appears.
 
-3.  In the body of the message, select the **Open Copilot** (pencil) icon that appears next to the attached file.
+2. In **Outlook on the web**, select **New mail** to create a new email and attach the Manager Performance file that you stored on your OneDrive at the end of the prior task.
 
-4.  The Copilot window that appears contains a prompt field and a menu of edit options below it. In the prompt field, ask Copilot to draft an email to Contoso’s HR Director that’s based on the attached Manager Summary report. The email should summarize the company’s recent manager performance metrics, strengths, and areas for improvement. It should also include actionable recommendations and specific data points from the table that are found in the attached file.
+3. In the body of the message, select the **Open Copilot** (pencil) icon that appears next to the attached file.
 
-5.  Review the results. Because the email is being sent to the HR Director, you want to tighten it up a bit. Ask Copilot to make the message concise and actionable.
+4. The Copilot window that appears contains a prompt field and a menu of edit options below it. In the prompt field, ask Copilot to draft an email to Contoso's HR Director that's based on the attached Manager Summary report. The email should summarize the company's recent manager performance metrics, strengths, and areas for improvement. It should also include actionable recommendations and specific data points from the table that are found in the attached file.
 
-6.  Review the updated email. Notice how Copilot generated a new version of the email, which is draft 2 (2 of 2). You can select the back arrow to go to draft 1 of 2, which was the original version of the email that Copilot generated. Since you prefer to keep working with the latest draft, select the forward arrow to return to draft 2 of 2.
+5. Review the results. Because the email is being sent to the HR Director, you want to tighten it up a bit. Ask Copilot to make the message concise and actionable.
+
+6. Review the updated email. Notice how Copilot generated a new version of the email, which is draft 2 (2 of 2). You can select the back arrow to go to draft 1 of 2, which was the original version of the email that Copilot generated. Since you prefer to keep working with the latest draft, select the forward arrow to return to draft 2 of 2.
 
    > [!NOTE]
    > For each request that you make, Copilot generates a new draft of the email. You can optionally navigate to a prior draft and keep it, or you can ask Copilot to modify that draft (rather than the last draft). By default, you typically make each new request while viewing the last draft.
 
-7.  While you’re satisfied with the contents of the email, you’re unsure about its tone. In the Copilot window, one of the edit options is **Change Tone**. Select one of the tones that you want from the menu that’s displayed.
+7. While you're satisfied with the contents of the email, you're unsure about its tone. In the Copilot window, one of the edit options is **Change Tone**. Select one of the tones that you want from the menu that's displayed.
 
-8.  Review the results. Continue to make any updates that you feel are necessary. Try different tones and lengths. Note how the draft number changes with each change request.
+8. Review the results. Continue to make any updates that you feel are necessary. Try different tones and lengths. Note how the draft number changes with each change request.
 
-9.  You can select the backward and forward arrows to go back through the prior drafts to view the changes. Review each of the drafts. Once you settle on a specific draft that you would like to use, ensure that draft is displayed in the draft window and then select the **Keep it** option in the Copilot menu.
+9. You can select the backward and forward arrows to go back through the prior drafts to view the changes. Review each of the drafts. Once you settle on a specific draft that you would like to use, ensure that draft is displayed in the draft window and then select the **Replace** option in the Copilot menu.
 
-10.  Review the results. Copilot should have inserted the draft into the actual body of the email. Now, once you use Copilot to draft the initial email, you can still use it to modify the email even after inserting the draft.
+10. Review the results. Copilot should have inserted the draft into the actual body of the email. Now, once you use Copilot to draft the initial email, you can still use it to modify the email even after inserting the draft.
     
-        - When modifying an actual email message, you must highlight the portion of the email that you want changed, whether it be a sentence, paragraph, or the entire email.
+      - When modifying an actual email message, you must highlight the portion of the email that you want changed, whether it be a sentence, paragraph, or the entire email.
     
-        - Or if you want Copilot to add more text to the email, you must position the cursor where you want Copilot to insert the text.
+      - Or if you want Copilot to add more text to the email, you must position the cursor where you want Copilot to insert the text.
         
-        In looking at the email, you decide to make one more change. You want to add one final paragraph at the end that mentions how you’re looking forward to moving ahead with these actionable insights to help improve the management culture at Contoso. You want this paragraph at the very end, so select the last sentence or paragraph in the email. That way, you can have Copilot insert this new paragraph below the selected sentence or paragraph. When you select into the email, note how Copilot displays the **Open Copilot** (pencil) icon. Select the **Open Copilot** icon.
+        In looking at the email, you decide to make one more change. You want to add one final paragraph at the end that mentions how you're looking forward to moving ahead with these actionable insights to help improve the management culture at Contoso. You want this paragraph at the very end, so select the last sentence or paragraph in the email. That way, you can have Copilot insert this new paragraph below the selected sentence or paragraph. When you select into the email, note how Copilot displays the **Open Copilot** (pencil) icon. Select the **Open Copilot** icon.
         
-11. In the Copilot window that appears, ask Copilot to add a paragraph that mentions how you’re looking forward to moving ahead with these actionable insights to help improve the management culture at Contoso.
+11. In the Copilot window that appears, ask Copilot to add a paragraph that mentions how you're looking forward to moving ahead with these actionable insights to help improve the management culture at Contoso.
 
-12.  Review the results. Note how Copilot displayed this content in the email and highlighted just this text. Only this highlighted content applies to the Copilot window that appears below it. You can continue to make more changes to this highlighted content just as you did with the initial email draft, or you can accept it as is. You like the paragraph, so select **Keep it**.
+12. Review the results. Note how Copilot displayed this content in the email and highlighted just this text. Only this highlighted content applies to the Copilot window that appears below it. You can continue to make more changes to this highlighted content just as you did with the initial email draft, or you can accept it as is. You like the paragraph, so select **Replace**.
 
-13.  Review the results. Instead of inserting the new section where it was shown in the Copilot window, the text was inserted at the start of the email. So, what’s going on here? Well, as of this writing, when you select **Keep it**, Copilot doesn’t insert the generated text exactly where your cursor is, or where you might have requested in your prompt (for example, if you asked it to add a new paragraph at the end of the email). Instead, Copilot uses an internal placeholder in Outlook’s email editor—and at present, that placeholder is always located at the top of the message body.  
-    <br/>So even though Copilot visually renders the generated paragraph where you requested it (to show you what it would look like), the actual insertion logic tied to the **Keep it** button doesn’t respect cursor position or prompt context. Rather, it appends the content to the default insertion point, which Outlook currently defines as the top of the message body.  
-    <br/>Until this feature is addressed, you must highlight the inserted text and then cut and paste it to your desired location. Highlight the paragraph, cut it (Ctrl+X), and then paste it (Ctrl+V) at the end of the email where you originally wanted it.
+13. Review the results. Copilot inserts the generated paragraph at the cursor position in the email body.
 
-14.  After reading through the email one last time, you aren’t sure about the message’s tone. Drag your cursor over the entire email so that it’s all highlighted, and then select the **Open Copilot** icon.
+14. After reading through the email one last time, you aren't sure about the message's tone. Drag your cursor over the entire email so that it's all highlighted, and then select the **Open Copilot** icon.
 
-15.  In the Copilot menu, scroll down and select **Change Tone** and then select the tone that you want from the menu that’s displayed.
+15. In the Copilot menu, scroll down and select **Change Tone** and then select the tone that you want from the menu that's displayed.
 
-16.  Review the results of the modified email that appears in the draft window. You still aren’t satisfied with the way the email sounds, so try a different tone.
+16. Review the results of the modified email that appears in the draft window. You still aren't satisfied with the way the email sounds, so try a different tone.
 
-17.  Review the new draft that Copilot generated. You still aren’t satisfied with the way the email sounds, so this time ask Copilot to change the tone by making it sound friendly and confident but still professional.
+17. Review the new draft that Copilot generated. You still aren't satisfied with the way the email sounds, so this time ask Copilot to change the tone by making it sound friendly and confident but still professional.
 
-18.  Review the results. You’re satisfied with this version, so select the **Keep it** option in the Copilot window. Doing so takes you out of Copilot draft mode and into the actual email itself.
+18. Review the results. You're satisfied with this version, so select the **Replace** option in the Copilot window. Doing so takes you out of Copilot draft mode and into the actual email itself.
 
-19.  Notice how Copilot replaced the original version of the email with this modified version. The email is now finished. If you want, go ahead and send it to your personal email address and then verify you received the email and it contains the attached document.
+19. Notice how Copilot replaced the original version of the email with this modified version. The email is now finished. If you want, go ahead and send it to your personal email address and then verify you received the email and it contains the attached document.
+
+> [!NOTE]
+> When you use Copilot to draft or modify an email, it may remove any previously attached files from the email body. Always verify that your attachments are still present before sending.
 

--- a/Instructions/Labs/M06-empower-workforce-copilot-hr/06-Ex1-4-use-loop-collaborative-planning.md
+++ b/Instructions/Labs/M06-empower-workforce-copilot-hr/06-Ex1-4-use-loop-collaborative-planning.md
@@ -18,41 +18,44 @@ You plan to use Microsoft Loop to organize and facilitate this process. You want
 
 Perform the following steps to complete this task:
 
-1.  In your Microsoft Edge browser, go to the **Microsoft 365** home page, select **Apps** in the navigation pane, and then select **Loop** from the **Apps** menu. If **Loop** doesn't appear in the list, select **All apps**. Under the top section of apps in the **Apps** window, select **All apps**. In the **All apps** window, scroll down and select **Loop**.
+1. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page, select **Apps** in the navigation pane, and then select **Loop** from the **Apps** menu. If **Loop** doesn't appear in the list, select **All apps**. Under the top section of apps in the **Apps** window, select **All apps**. In the **All apps** window, scroll down and select **Loop**.
 
-2.  In **Loop for the web**, create a new workspace titled **Contoso Manager Development Plans**.
+   > [!NOTE]
+   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Loop** from the list of apps that appears.
 
-3.  While the Manager Performance PDF file contains insights on 15 Contoso managers that you analyzed in earlier tasks, this training doesn’t have enough time to summarize the findings for all 15 of them. To give you an appreciation for how this exercise would work in a real-world scenario without being overly time-consuming, this task only focuses on two of the managers, Jacob Hancock and Kerry Allen.  
+2. In **Loop for the web**, select the plus sign **(+)** icon, then select **New workspace** to create a new workspace titled **Contoso Manager Development Plans**. Select the **Create** button.
+
+3. While the Manager Performance PDF file contains insights on 15 Contoso managers that you analyzed in earlier tasks, this training doesn't have enough time to summarize the findings for all 15 of them. To give you an appreciation for how this exercise would work in a real-world scenario without being overly time-consuming, this task only focuses on two of the managers, Jacob Hancock and Kerry Allen.  
     
     You want to create a Loop page for each manager. To begin, change the current title of the first page from **Untitled** to **Jacob Hancock**. Then create another page under this Loop workspace for **Kerry Allen**.
 
-4.  Select the **Jacob Hancock** page and then open the Copilot pane.
+4. Select the **Jacob Hancock** page and then open the Copilot pane.
 
-5.  In the Copilot prompt field, attach the Manager Performance PDF file that you created and stored on your OneDrive at the end of Task 2. To do so, select the **Reference files** (+ sign) icon in the prompt field and select the PDF file that you created in Task 2. 
+5. In the Copilot prompt field, attach the Manager Performance PDF file that you created and stored on your OneDrive at the end of Task 2. To do so, select the **Reference files** (+ sign) icon in the prompt field and select the PDF file that you created in Task 2. 
 
    > [!TIP]
-   > If the PDF file doesn’t appear in the menu of files that’s displayed, enter **/Contoso** in the prompt field to display all files in your OneDrive that start with **Contoso**. The list should include the PDF file that you created in Task 2. Select this file.
+   > If the PDF file doesn't appear in the menu of files that's displayed, enter **/Contoso** in the prompt field to display all files in your OneDrive that start with **Contoso**. The list should include the PDF file that you created in Task 2. Select this file.
 
-6.  Ask Copilot to summarize Jacob Hancock’s top strengths and development areas based on the attached report. Also ask Copilot to suggest three actionable steps that Jacob Hancock can take to improve team engagement and reduce attrition.
+6. Ask Copilot to summarize Jacob Hancock's top strengths and development areas based on the attached report. Also ask Copilot to suggest three actionable steps that Jacob Hancock can take to improve team engagement and reduce attrition.
 
-7.  Review the results. Select the **Copy** icon that appears after the results and then paste **(Ctrl+V)** the copied content into Jacob’s Loop page. Delete the conversational text that appears at the start and end of the content that was pasted into the page.
+7. Review the results. Select the **Copy** icon that appears after the results and then paste **(Ctrl+V)** the copied content into Jacob's Loop page. Delete the conversational text that appears at the start and end of the content that was pasted into the page.
 
-8.  Select **Kerry Allen’s** Loop page. Notice what happened—the Copilot pane disappeared. Now scroll down past the suggested prompts and select the **Chat History** button. It should display a message indicating there’s no previous Copilot chats in this document. So when you switch Loop pages, you can’t access the chat history associated with another page.
+8. Select **Kerry Allen's** Loop page. Notice what happened—the Copilot pane disappeared. Now open the Copilot pane again, scroll down past the suggested prompts, and select the **Chat History** button. It should display a message indicating there are no previous Copilot chats in this document. So when you switch Loop pages, you can't access the chat history associated with another page.
     
    > [!NOTE]
    > In Microsoft Loop, the Copilot pane is context-sensitive and operates exclusively within the currently open page. Any prompts, responses, or chat history you access are specific to that page alone—Copilot doesn't retain or display conversations from other pages in the workspace. This design ensures that your analysis and collaboration remain focused and organized, with each page serving as a distinct workspace for its own set of Copilot insights and discussions.
 
-9.  Select **Jacob Hancock’s** Loop page again. Note how Copilot opened a new pane that didn’t display the previous conversation related to Jacob. When you return to a Loop page, you can either start a new Copilot chat session for that page or return to an existing one. 
+9. Select **Jacob Hancock's** Loop page again. Select the Copilot pane and note how Copilot didn't display the previous conversation related to Jacob. When you return to a Loop page, you can either start a new Copilot chat session for that page or return to an existing one. 
 
     To see how you can return to a prior conversation, scroll down past the suggested prompts and select the **Chat History** button. It should display lines from each of the previous chat sessions for this Loop page. In this case, there should just be one chat session, so select the line to open that conversation. 
 
-10.  We asked you to perform these prior two steps to see how Copilot in Loop handles chat sessions within Loop pages. We now want you to perform the same analysis on Kerry’s Loop pages that you did with Jacob. To do so, repeat steps 4-7 for Kerry.
+10. We asked you to perform these prior two steps to see how Copilot in Loop handles chat sessions within Loop pages. We now want you to perform the same analysis on Kerry's Loop pages that you did with Jacob. To do so, repeat steps 4-7 for Kerry.
 
-11.  Next, add a new page under your **Contoso Manager Development Plans** workspace. Change the title of this page to **Action Plan Summary**.
+11. Next, add a new page under your **Contoso Manager Development Plans** workspace. Change the title of this page to **Action Plan Summary**.
 
-12.  Open the Copilot pane for this new page. Then ask Copilot to review the action plans in each Loop page for this workspace and summarize how the action plans for each manager could be implemented in a real organization, including potential challenges, support needed, and how progress would be tracked.
+12. Open the Copilot pane for this new page. Then ask Copilot to review the action plans in each Loop page for this workspace and summarize how the action plans for each manager could be implemented in a real organization, including potential challenges, support needed, and how progress would be tracked.
 
-13.  Review the results and then copy and paste the content into the **Action Plan Summary** page. Delete any extraneous text that was copied and pasted along with the ideas.
+13. Review the results and then copy and paste the content into the **Action Plan Summary** page. Delete any extraneous text that was copied and pasted along with the ideas.
 
 You just created a collaborative Loop workspace that could serve as the central hub for manager development planning. This task provided a realistic experience of facilitating manager development planning in a modern HR environment, using Loop and Copilot as collaborative tools.
 

--- a/Instructions/Labs/M06-empower-workforce-copilot-hr/06-Ex1-4-use-loop-collaborative-planning.md
+++ b/Instructions/Labs/M06-empower-workforce-copilot-hr/06-Ex1-4-use-loop-collaborative-planning.md
@@ -18,10 +18,7 @@ You plan to use Microsoft Loop to organize and facilitate this process. You want
 
 Perform the following steps to complete this task:
 
-1. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page, select **Apps** in the navigation pane, and then select **Loop** from the **Apps** menu. If **Loop** doesn't appear in the list, select **All apps**. Under the top section of apps in the **Apps** window, select **All apps**. In the **All apps** window, scroll down and select **Loop**.
-
-   > [!NOTE]
-   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Loop** from the list of apps that appears.
+1. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page, select the **App Launcher** (grid icon), and then select **More Apps**. From the list of apps, select **Loop**.
 
 2. In **Loop for the web**, select the plus sign **(+)** icon, then select **New workspace** to create a new workspace titled **Contoso Manager Development Plans**. Select the **Create** button.
 

--- a/Instructions/Labs/M06-empower-workforce-copilot-hr/07-Ex2-introduction-empower-employees-exercise.md
+++ b/Instructions/Labs/M06-empower-workforce-copilot-hr/07-Ex2-introduction-empower-employees-exercise.md
@@ -9,11 +9,11 @@ lab:
 
 # Exercise 2: Empower employees with an HR self-service agent
 ---
-Modern HR departments are increasingly using Microsoft 365 Copilot to enhance employee support, streamline communication, and reduce administrative workload. Through a combination of custom-built Copilot agents and Microsoft’s prebuilt agents, HR teams can deliver faster, more accurate responses to employee inquiries while maintaining consistency with company policy.
+Modern HR departments are increasingly using Microsoft 365 Copilot to enhance employee support, streamline communication, and reduce administrative workload. Through a combination of custom-built Copilot agents and Microsoft's prebuilt agents, HR teams can deliver faster, more accurate responses to employee inquiries while maintaining consistency with company policy.
 
-For example, an HR department can build a custom agent that enables employees to instantly access information about benefits, promotions, relocation, and workplace policies without waiting for HR staff. Custom-built agents scan improve both service quality and operational efficiency.
+For example, an HR department can build a custom agent that enables employees to instantly access information about benefits, promotions, relocation, and workplace policies without waiting for HR staff. Custom-built agents can improve both service quality and operational efficiency.
 
-Meanwhile, prebuilt Copilot agents like Researcher empower employees and HR professionals to gather and synthesize external insights to support informed decision-making. Together, these tools demonstrate how intelligent agents in Microsoft 365 can extend HR’s impact and foster a more connected, data-driven workplace.
+Meanwhile, prebuilt Copilot agents like Researcher empower employees and HR professionals to gather and synthesize external insights to support informed decision-making. Together, these tools demonstrate how intelligent agents in Microsoft 365 can extend HR's impact and foster a more connected, data-driven workplace.
 
 > [!TIP]
 > The Introduction unit in this module reminded you of the four key elements of an effective prompt: Goal, Context, Sources, and Expectations. Keep these elements in mind as you create prompts in this exercise.
@@ -22,7 +22,7 @@ Meanwhile, prebuilt Copilot agents like Researcher empower employees and HR prof
 
 In this exercise, you take on two roles—first as an HR Analyst who creates both an HR self-service agent and a Viva Engage announcement for the new agent, and then as an Adatum employee who is relocating to a new city following a recent promotion. 
 
-The employee uses the HR self-service agent to get answers about company policies, including the company’s relocation policy. The employee then uses the Researcher agent to investigate schools in the employee’s new city, in preparation for their relocation.
+The employee uses the HR self-service agent to get answers about company policies, including the company's relocation policy. The employee then uses the Researcher agent to investigate schools in the employee's new city, in preparation for their relocation.
 
 This exercise demonstrates how Copilot Chat can connect company data and web sources to support both internal operations and individual productivity.
 

--- a/Instructions/Labs/M06-empower-workforce-copilot-hr/08-Ex2-1-create-self-service-agent.md
+++ b/Instructions/Labs/M06-empower-workforce-copilot-hr/08-Ex2-1-create-self-service-agent.md
@@ -12,7 +12,7 @@ lab:
 
 # Exercise 2, Task 1: Create an HR self-service agent for company employees
 ---
-You’re an HR Analyst at Adatum Corporation, a mid-sized technology firm with approximately 3,000 employees across multiple U.S. locations. Adatum’s HR department receives hundreds of inquiries each month about benefits, promotions, relocation, and other company policies.
+You're an HR Analyst at Adatum Corporation, a mid-sized technology firm with approximately 3,000 employees across multiple U.S. locations. Adatum's HR department receives hundreds of inquiries each month about benefits, promotions, relocation, and other company policies.
 
 To reduce costs and improve service, you were asked to create an HR self-service agent in Microsoft 365 Copilot. The purpose of this agent is to answer employee questions using official HR policy documents as its knowledge base.
 
@@ -21,7 +21,7 @@ To reduce costs and improve service, you were asked to create an HR self-service
 
 Perform the following steps to complete this task:
 
-1.  Select each of the following links to download their respective HR policy files and store them in your OneDrive account:
+1. Select each of the following links to download their respective HR policy files and store them in your OneDrive account:
 
     - [**Adatum Code of Conduct and Workplace Behavior.docx**](https://go.microsoft.com/fwlink/?linkid=2347608)
 
@@ -35,86 +35,94 @@ Perform the following steps to complete this task:
 
     - [**Adatum Remote Work and Flexible Schedule Policy.docx**](https://go.microsoft.com/fwlink/?linkid=2347610)
 
-2.  In your Microsoft Edge browser, sign in to the **Microsoft 365** home page **(https://www.microsoft365.com)**.
+2. In your Microsoft Edge browser, sign in to the **Microsoft 365 Copilot** home page [**(https://www.microsoft365.com)**](https://www.microsoft365.com).
 
-3.  In Microsoft 365, select **New agent** in the navigation pane. Doing so opens Copilot Studio’s **Agent Builder** and displays the **New agent** page.
+3. In Microsoft 365 Copilot, select **Agents** in the navigation pane, then select **Create agent**. Doing so opens Copilot Studio's **Agent Builder** and displays the **New agent** page.
 
-4.  On the **New Agent** page, you want to ask Copilot to create an agent. In the prompt, you should enter the agent’s name and a general description of what the agent is about, who its target audience is, and what you want it to do.  
-    <br/>For this agent, enter the following prompt and then select the forward arrow (Send) icon to submit the prompt:  
-    <br/>**Create an agent titled HR Self-Service Assistant. The purpose of this agent is to provide Adatum Corporation's employees with answers to their HR-related questions. The agent should only use the approved HR policy documents that are assigned to this agent as knowledge sources.**
+4. On the **New agent** page, you want to ask Copilot to create an agent. In the prompt, you should enter the agent's name and a general description of what the agent is about, who its target audience is, and what you want it to do.  
+    
+    For this agent, enter the following prompt and then select the forward arrow (Send) icon to submit the prompt:  
+    
+    **Create an agent titled HR Self-Service Assistant. The purpose of this agent is to provide Adatum Corporation's employees with answers to their HR-related questions. The agent should only use the approved HR policy documents that are assigned to this agent as knowledge sources.**
 
-5.  After you selected the forward arrow, the **Agent Builder** form appeared for your new agent. At the top of the form is a **Describe** tab and a **Configure** tab.
+5. After you selected the forward arrow, the **Agent Builder** form appeared for your new agent. The **Agent Builder** chat pane appears on the left, and the agent details appear on the right. At the top of the form are a **Configure** tab and a **Preview** tab.
 
-    - The **Describe** tab enables you to carry on a conversation with Copilot. This tab is displayed by default.
+    - The **Agent Builder** chat pane on the left enables you to carry on a conversation with Copilot to refine your agent.
 
-    - The **Configure** tab enables you to define the detailed settings that drive the agent.
+    - The **Preview** tab enables you to test the agent by entering starter prompts or custom messages.
 
-    Wait a minute or two for Copilot to create the agent, at which time it displays the agent’s name and description in the **Agent preview** pane.
+    Wait a minute or two for Copilot to create the agent, at which time it displays the agent's name and description in the **Agent preview** pane.
 
-6.  Select the **Configure** tab at the top of the form. Let’s see what Copilot did based on the prompt that you entered.
+6. Select the **Configure** tab at the top of the form. Let's see what Copilot did based on the prompt that you entered.
 
-7.  On the **Configure** tab, the **Name** and **Description** fields should be filled in based on the prompt that you entered. Scroll down to the **Instructions** field. Copilot generated these instructions based on the description that you provided in your initial prompt. Review the detailed level of instructions that Copilot generated.
+7. On the **Configure** tab, the **Name** and **Description** fields should be filled in based on the prompt that you entered. Scroll down to the **Instructions** field. Copilot generates these instructions based on the description that you provided in your initial prompt. Review the detailed level of instructions that Copilot generated.
 
    > [!IMPORTANT]
    > The beauty of the Agent Builder process is that Copilot automatically translates your basic, natural language description into a complex set of instructions. This process saves you from creating this detailed instruction set on your own.
 
-8.  If you wish to change the instructions, you can either manually edit them directly in the **Instructions** field, or you can ask Copilot to update the instructions for you.  
-    <br/>After reviewing the **Instructions**, you decide that you want to have Copilot add a couple of other items to the instruction set. To do so, select the **Describe** tab and then enter the following prompt:
+8. If you wish to change the instructions, you can either manually edit them directly in the **Instructions** field, or you can ask Copilot to update the instructions for you.  
+    
+    After reviewing the **Instructions**, you decide that you want to have Copilot add a couple of other items to the instruction set. To do so, select the **Agent Builder** chat pane and then enter the following prompt:
 
     **Update the Instructions to include the following items:**
 
     - **Cite a source for every answer.**
-    - **Don’t speculate. If information is missing or ambiguous, flag the gap and provide a polite fallback response, such as: “I don’t have a verified answer in the assigned HR sources. Please contact HR Support or see the HR Policy Portal."**
-    - **Politely decline sensitive or case‑specific topics (compensation details, medical data, manager‑only policies) with a privacy‑aware message and redirect: “I can’t access or share personal/sensitive information. Please contact HR Support for individualized assistance.”**
+    - **Don't speculate. If information is missing or ambiguous, flag the gap and provide a polite fallback response, such as: "I don't have a verified answer in the assigned HR sources. Please contact HR Support or see the HR Policy Portal."**
+    - **Politely decline sensitive or case-specific topics (compensation details, medical data, manager-only policies) with a privacy-aware message and redirect: "I can't access or share personal/sensitive information. Please contact HR Support for individualized assistance."**
     - **Avoid jargon; define terms briefly if needed.**
 
-9.  Review Copilot’s response after updating the instructions. To verify the changes that Copilot made, select the **Configure** tab and then scroll down to the **Instructions** field. Verify that Copilot added the new instructions that you requested.
+9. Review Copilot's response after updating the instructions. To verify the changes that Copilot made, select the **Configure** tab and then scroll down to the **Instructions** field. Verify that Copilot added the new instructions that you requested.
 
-10.  While the current instructions look good, you wonder if they could be improved upon. You aren't sure how to improve them, so you decide to ask Copilot what it thinks.  
-    <br/>To do so, select the **Describe** tab. This time, enter a prompt that asks Copilot what other instructions it would recommend that could improve this agent.
+10. While the current instructions look good, you wonder if they could be improved upon. You aren't sure how to improve them, so you decide to ask Copilot what it thinks.  
 
-11.  Review Copilot’s recommendations. You’re pleased with its suggestions, so ask Copilot to add them all to the agent’s instructions.
+    To do so, select the **Agent Builder** chat pane. This time, enter a prompt that asks Copilot what other instructions it would recommend that could improve this agent.
 
-12.  Once Copilot responds that it updated the instructions, select the **Configure** tab and scroll through the **Instructions**. Note the new items that Copilot added.
+11. Review Copilot's recommendations. You're pleased with its suggestions, so ask Copilot to add them all to the agent's instructions.
 
-13.  Now that you’re satisfied with the instructions, you’re ready to configure the agent’s knowledge sources and starter prompts.  
-    <br/>In the **Configure** tab, scroll down to the **Knowledge** section and verify the **Search all websites** toggle switch is disabled. Copilot should have disabled this toggle switch when it created the agent based on the description you provided in your original prompt, which told it to only use the files that you provide. If the toggle switch is enabled, then disable it now.
+12. Once Copilot responds that it updated the instructions, select the **Configure** tab and scroll through the **Instructions**. Note the new items that Copilot added.
 
-14.  In the **Knowledge** section, select the **Upload from device** icon that appears next to the **Enter a URL or name or drop files here** field. In the **File Explorer** window that appears, navigate to your **OneDrive** folder and select the six files that you downloaded in step 1 and stored on your OneDrive.
+13. Now that you're satisfied with the instructions, you're ready to configure the agent's knowledge sources and starter prompts.  
+    
+    In the **Configure** tab, scroll down to the **Knowledge** section and verify the **Web search** toggle switch is disabled. Copilot should have disabled this toggle switch when it created the agent based on the description you provided in your original prompt, which told it to only use the files that you provide. If the toggle switch is enabled, then disable it now.
 
-15.  For **Suggested prompts**, you can have Copilot generate prompts for you, or you can manually create your own prompts. Let’s try both methods.  
-    <br/>To have Copilot generate suggested prompts, select the **Describe** tab and then ask Copilot to generate three suggested prompts for the agent. Note how each prompt has a title and a message.
+14. In the **Knowledge** section, select the **+ Add knowledge** button. In the data picker that appears, use the search field (**Paste a link or search for your data**) or the **Files** tab to locate and select the six files that you downloaded in step 1 and stored on your OneDrive.
 
-16.  You now want to enter several of your own prompts. Select the **Configure** tab and scroll down to the **Suggested prompts** section. You should see the three prompts that Copilot added to the agent.  
-    <br/>For each prompt that you want to manually add, select the **Add a suggested prompt** option that appears below the prompts.  
-    <br/>Six suggested prompts are displayed below that are related to popular HR-related topics. Review these prompts, select two or three that you like, and then add them to the agent.
+15. For **Suggested prompts**, you can have Copilot generate prompts for you, or you can manually create your own prompts. Let's try both methods.  
+    
+    To have Copilot generate suggested prompts, select the **Agent Builder** chat pane and then ask Copilot to generate three suggested prompts for the agent. Note how each prompt has a title and a message.
 
-        - **Title:** Relocation Policy
-            - **Message:** What is Adatum’s relocation policy for employees who are moving due to a promotion?  
+16. You now want to enter several of your own prompts. Select the **Configure** tab and scroll down to the **Suggested prompts** section. You should see the three prompts that Copilot added to the agent.  
+    
+    For each prompt that you want to manually add, select the **Add a suggested prompt** option that appears below the prompts.  
+    
+    Six suggested prompts are displayed below that are related to popular HR-related topics. Review these prompts, select two or three that you like, and then add them to the agent.
+
+    - **Title:** Relocation Policy
+        - **Message:** What is Adatum's relocation policy for employees who are moving due to a promotion?  
                 
-        - **Title:** Benefits Enrollment & Plan Changes
-            - **Message:** When is the next open enrollment window for benefits, and how do I change my medical or dental plan?  
+    - **Title:** Benefits Enrollment & Plan Changes
+        - **Message:** When is the next open enrollment window for benefits, and how do I change my medical or dental plan?  
                 
-        - **Title:** Paid time off (PTO) & Leave
-            - **Message:** How does PTO accrue at Adatum, what is the year‑end carryover policy, and how do I submit a PTO request?  
+    - **Title:** Paid time off (PTO) & Leave
+        - **Message:** How does PTO accrue at Adatum, what is the year-end carryover policy, and how do I submit a PTO request?  
                 
-        - **Title:** Promotion Criteria
-            - **Message:** What are the general promotion criteria for moving from an individual contributor role to a manager role at Adatum?  
+    - **Title:** Promotion Criteria
+        - **Message:** What are the general promotion criteria for moving from an individual contributor role to a manager role at Adatum?  
                 
-        - **Title:** Paydays, Deductions, and Pay Statements
-            - **Message:** When are regular paydays, where can I find my pay statements, and how are common deductions (benefits, taxes, retirement) handled?  
+    - **Title:** Paydays, Deductions, and Pay Statements
+        - **Message:** When are regular paydays, where can I find my pay statements, and how are common deductions (benefits, taxes, retirement) handled?  
                 
-        - **Title:** Parental Leave
-            - **Message:** What is Adatum’s parental leave policy?  
+    - **Title:** Parental Leave
+        - **Message:** What is Adatum's parental leave policy?  
                 
-17.  Test several of the suggested prompts (you submit custom prompts in the next task). Verify the agent is correctly pulling in data from the knowledge source documents. You perform more extensive usage of this agent in a later task.
+17. Test several of the suggested prompts (you submit custom prompts in the next task). Verify the agent is correctly pulling in data from the knowledge source documents. You perform more extensive usage of this agent in a later task.
 
-18. Once you’re satisfied with the results for the suggested prompts, select the **Create** button to create the agent.
+18. Once you're satisfied with the results for the suggested prompts, select the **Create** button to create the agent.
 
 19. Once the agent is created, a dialog box appears that indicates the agent was successfully created. In this dialog box, you can either go to the agent or share it. Select the **Go to agent** option.
 
 > [!NOTE]
-> At this stage, the agent is private and accessible only to you. In a real-world scenario where the agent needs to be used by multiple team members, you would share it with those individuals. For this training exercise, sharing isn’t required since you’re working within your own tenant.
+> At this stage, the agent is private and accessible only to you. In a real-world scenario where the agent needs to be used by multiple team members, you would share it with those individuals. For this training exercise, sharing isn't required since you're working within your own tenant.
 
 
 

--- a/Instructions/Labs/M06-empower-workforce-copilot-hr/09-Ex2-2-use-viva-engage-announce-agent.md
+++ b/Instructions/Labs/M06-empower-workforce-copilot-hr/09-Ex2-2-use-viva-engage-announce-agent.md
@@ -11,32 +11,33 @@ lab:
 ---
 Adatum is rolling out its new **HR Self-Service Assistant** agent, designed to empower employees to get instant answers to common HR questions—such as benefits, leave policies, and onboarding—directly within Microsoft 365. In your role as an HR Analyst, you completed building and testing the agent (Task 1). Now, you must ensure employees are aware of this new resource and feel confident using it.
 
-Adatum's Chief People Officer asked you to create a company-wide announcement in Viva Engage. The goal is to introduce the HR self-service agent, highlight its benefits, and encourage employees to try it out and share feedback. You want to post this announcement in testing community to ensure it meets all requirements. Once you’re satisfied with the results, you then plan to post it in Adatum’s company community so that it reaches all staff.
+Adatum's Chief People Officer asked you to create a company-wide announcement in Viva Engage. The goal is to introduce the HR self-service agent, highlight its benefits, and encourage employees to try it out and share feedback. You want to post this announcement in testing community to ensure it meets all requirements. Once you're satisfied with the results, you then plan to post it in Adatum's company community so that it reaches all staff.
 
 Perform the following steps to complete this task:
 
-1.  In your Microsoft Edge browser, go to the **Microsoft 365** home page and select **Apps** in the navigation pane. In the **Apps** menu that appears, select **All apps**. Under the top section of apps in the **Apps** window, select **All apps→**. In the **All apps** window, scroll down and select **Viva.**
-
-2.  On the **Viva** home page, select **Engage** in the navigation pane.
-
-3.  In **Viva Engage**, you should begin by creating a new community for testing the Viva Engage announcement that you create later in this task. To do so, select **+Create new** at the top of the **Viva Engage** navigation pane, and then select **Community** in the drop-down menu that appears.
-
-4.  In the **Create a new community** window, enter **Adatum HR agent testing** in the **Name** field, and enter **This community is used for testing the Viva Engage announcement for Adatum’s new HR Self-Service Assistant** **agent** in the **Description** field. Select the **Create** button.
-
-5.  In **Viva Engage**, select **+Create new** at the top of the navigation pane, and then select **Post** in the drop-down menu that appears.
-
-6.  In the **Post** window, select the **Copilot** icon to open the Copilot pane.
-
-7.  Copy and paste the following prompt that asks Copilot to draft a Viva Engage announcement highlighting the rollout of TR-Pulse:
+1. In your Microsoft Edge browser, go to the **Microsoft 365** home page and select **Apps** in the navigation pane. In the **Apps** menu that appears, select **All apps**. Under the top section of apps in the **Apps** window, select **All apps**. In the **All apps** window, scroll down and select **Engage**.
 
    > [!NOTE]
-   > For this first prompt, we’ve provided the text so you can see what an effective prompt looks like when it incorporates the four key elements discussed in the Introduction unit. You must write all remaining prompts in this exercise, but in doing so, you can use this prompt as a model to emulate.
+   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Engage** from the list of apps that appears.
+
+2. In **Viva Engage**, you should begin by creating a new community for testing the Viva Engage announcement that you create later in this task. To do so, select **+ Create new** at the top of the **Viva Engage** navigation pane, and then select **Community** in the drop-down menu that appears.
+
+3. In the **Create a new community** window, enter `Adatum HR agent testing` in the **Name** field, and enter `This community is used for testing the Viva Engage announcement for Adatum's new HR Self-Service Assistant agent` in the **Description** field. Select the **Create** button.
+
+4. In **Viva Engage**, select **+ Create new** at the top of the navigation pane, and then select **Post** in the drop-down menu that appears.
+
+5. In the **Post** window, select the **Copilot** icon to open the Copilot pane.
+
+6. Copy and paste the following prompt that asks Copilot to draft a Viva Engage announcement highlighting the rollout of the HR Self-Service Assistant:
+
+   > [!NOTE]
+   > For this first prompt, we've provided the text so you can see what an effective prompt looks like when it incorporates the four key elements discussed in the Introduction unit. You must write all remaining prompts in this exercise, but in doing so, you can use this prompt as a model to emulate.
     
-   **As the HR Analyst at Adatum Corporation, I’ve been tasked with creating a company-wide launch announcement for an employee community post. Adatum is introducing the HR Self-Service Assistant, a new Copilot agent designed to help employees get instant answers to HR questions about company policies, benefits, leave, and more—anytime, anywhere.**
+   **As the HR Analyst at Adatum Corporation, I've been tasked with creating a company-wide launch announcement for an employee community post. Adatum is introducing the HR Self-Service Assistant, a new Copilot agent designed to help employees get instant answers to HR questions about company policies, benefits, leave, and more—anytime, anywhere.**
     
    **I plan to publish the announcement in Viva Engage to maximize awareness and encourage engagement across our diverse workforce. Can you draft this announcement for me? It should be a clear, engaging Viva Engage post that:**
     
-   - **Explains the purpose of the HR Self-Service Assistant and why it’s valuable now**
+   - **Explains the purpose of the HR Self-Service Assistant and why it's valuable now**
    - **Describes what employees can expect from the assistant (for example, types of questions it can answer, how it improves access to HR information, and privacy assurances)**
    - **Provides simple steps on how employees can access and use the assistant (where to find it, how to start a conversation, and tips for getting the best answers)**
    - **Invites early engagement through reactions and comments, and encourages employees to share feedback or tag colleagues who might benefit**
@@ -44,51 +45,52 @@ Perform the following steps to complete this task:
    **The announcement should include the following expectations and constraints:**
     
    - **Audience: all employees (on-site, remote, and hybrid) across departments and locations**
-   - **Tone: friendly, supportive, inclusive, and aligned with Adatum’s values**
+   - **Tone: friendly, supportive, inclusive, and aligned with Adatum's values**
    - **Style: short paragraphs; scannable subheads; 1–2 links/placeholders to resources or help guides; a clear call to action**
    - **Add 3–4 relevant hashtags (for example, #AdatumHR #SelfService #EmployeeSupport #AskHR) and mention the HR community**
    - **Avoid jargon; prioritize clarity and accessibility**
     
-   **We’re excited to kick off this initiative and make HR support easier for everyone. The announcement should encourage employees to try the assistant, share their experiences, and help us improve the tool for all.**
+   **We're excited to kick off this initiative and make HR support easier for everyone. The announcement should encourage employees to try the assistant, share their experiences, and help us improve the tool for all.**
 
-8.  Review the generated announcement. In the next steps, you edit the announcement before posting it.
+7. Review the generated announcement. In the next steps, you edit the announcement before posting it.
 
    > [!TIP]
-   > In Viva Engage, Copilot is strongest before and during composition (drafting, rewriting, tone/length coaching, conversation starters, and so on) and around the post (suggesting where/what to post, summarizing context, prompting engagement). After an announcement is published, Copilot can’t directly edit the live post that’s in place. Instead, you must make changes by manually editing the post content yourself. Copilot can still help by suggesting improved wording or generating assets you then paste or insert.
+   > In Viva Engage, Copilot is strongest before and during composition (drafting, rewriting, tone/length coaching, conversation starters, and so on) and around the post (suggesting where/what to post, summarizing context, prompting engagement). After an announcement is published, Copilot can't directly edit the live post that's in place. Instead, you must make changes by manually editing the post content yourself. Copilot can still help by suggesting improved wording or generating assets you then paste or insert.
 
-9.  In the Copilot pane, review the opening sentences of the announcement. Copilot often starts with something generic like “We’re excited to announce…”. While that type of opening is fine, Viva Engage is most effective when posts open with a clear, human explanation of why something matters to employees. Ask Copilot to reword the first 1–2 sentences to address employees directly, emphasize why this agent matters to them, and set a conversational tone. Shift the message from a corporate announcement to a personal invitation.
+8. In the Copilot pane, review the opening sentences of the announcement. Copilot often starts with something generic like "We're excited to announce…". While that type of opening is fine, Viva Engage is most effective when posts open with a clear, human explanation of why something matters to employees. Ask Copilot to reword the first 1–2 sentences to address employees directly, emphasize why this agent matters to them, and set a conversational tone. Shift the message from a corporate announcement to a personal invitation.
 
-10.  Review the revised opening. You like what Copilot did, but you decide to make one other change to give the announcement a more personal touch. You feel that it would make the agent more relatable by adding several quotes from employees who were involved in the pilot project. Ask Copilot to add the following quotes from pilot users about the benefits of using the agent:
+9. Review the revised opening. You like what Copilot did, but you decide to make one other change to give the announcement a more personal touch. You feel that it would make the agent more relatable by adding several quotes from employees who were involved in the pilot project. Ask Copilot to add the following quotes from pilot users about the benefits of using the agent:
 
-        - “I used the HR Self-Service Assistant to check my vacation balance and got an answer in seconds—no more waiting for email replies!”  
+    - "I used the HR Self-Service Assistant to check my vacation balance and got an answer in seconds—no more waiting for email replies!"  
             — Hannah L., Marketing Specialist
     
-        - “It’s great to have instant access to HR policies, especially when I’m working remotely. The assistant is easy to use and always available.”  
+    - "It's great to have instant access to HR policies, especially when I'm working remotely. The assistant is easy to use and always available."  
             — Stacy K., Software Engineer
     
-        - “I was able to find information about parental leave and submit my questions after hours. The agent made the process simple and stress-free.”  
+    - "I was able to find information about parental leave and submit my questions after hours. The agent made the process simple and stress-free."  
             — Emily T., Customer Support Lead
     
-        - “The assistant helped me understand our new benefits package without having to schedule a meeting. It was a real time-saver!”  
+    - "The assistant helped me understand our new benefits package without having to schedule a meeting. It was a real time-saver!"  
             — Abby B., Financial Analyst
     
-        - “I was concerned about the agent divulging personal information, such as my salary, my pay level, and so on. I thoroughly tested it to see if it would share any confidential details, and it didn't provide any personal information at all. I felt a whole lot better about using the agent after running those tests.”  
+    - "I was concerned about the agent divulging personal information, such as my salary, my pay level, and so on. I thoroughly tested it to see if it would share any confidential details, and it didn't provide any personal information at all. I felt a whole lot better about using the agent after running those tests."  
             — Chet F., Operations Coordinator
     
-11.  Review the employee testimonials. Since you’re satisfied with how it turned out, ask Copilot to rewrite the entire announcement by using the revised opening sentences and employee testimonials that it created.
+10. Review the employee testimonials. Since you're satisfied with how it turned out, ask Copilot to rewrite the entire announcement by using the revised opening sentences and employee testimonials that it created.
 
-12.  Review the results. In our testing, Copilot rewrote the announcement, but it didn’t use the revised opening or testimonials; instead, it rewrote them again to something different. This version isn’t what we wanted, so we asked Copilot to rewrite the announcement, and this time we specifically asked it to use the revisions to the opening and the employee quotations that it originally proposed. In our testing, Copilot applied its original revisions.  
-    <br/>Check your results. Did Copilot do the same as it did in our testing, or did it apply its original revisions? If it rewrote everything over again, then ask it to rewrite the post using its original revisions.
+11. Review the results. In our testing, Copilot rewrote the announcement, but it didn't use the revised opening or testimonials; instead, it rewrote them again to something different. This version isn't what we wanted, so we asked Copilot to rewrite the announcement, and this time we specifically asked it to use the revisions to the opening and the employee quotations that it originally proposed. In our testing, Copilot applied its original revisions.  
+    
+    Check your results. Did Copilot do the same as it did in our testing, or did it apply its original revisions? If it rewrote everything over again, then ask it to rewrite the post using its original revisions.
 
-13.  Once you’re satisfied with the announcement, select the **+Add to post** option that appears at the end of the results in the Copilot pane.
+12. Once you're satisfied with the announcement, select the **+ Add to post** option that appears at the end of the results in the Copilot pane.
 
-14.  Review the announcement that appears in the post window. Delete any of the extraneous Copilot chat text that appears at the start and end of the post, such as “You asked for a…”).
+13. Review the announcement that appears in the post window. Delete any of the extraneous Copilot chat text that appears at the start and end of the post, such as "You asked for a…".
 
-15.  Before you can post this announcement, you must first select a community or storyline. However, because you created the **Adatum HR agent testing** community at the start of this task, and since that community was displayed in Viva Engage when you created this post, the announcement should appear at the bottom of the post window, above the menu bar. If a **Select a community or storyline** option appears at the bottom of the Viva Engage post instead, then select it and select the **Adatum HR agent testing** community from the menu that appears.
+14. Before you can post this announcement, you must first select a community or storyline. However, because you created the **Adatum HR agent testing** community at the start of this task, and since that community was displayed in Viva Engage when you created this post, the announcement should appear at the bottom of the post window, above the menu bar. If a **Select a community or storyline** option appears at the bottom of the Viva Engage post instead, then select it and select the **Adatum HR agent testing** community from the menu that appears.
 
-16.  Select the **Post** button.
+15. Select the **Post** button.
 
-17.  In the **Adatum HR agent testing** community, you should see the post that Copilot just created for you.
+16. In the **Adatum HR agent testing** community, you should see the post that Copilot just created for you.
 
 In an actual rollout, you would post your announcement in the testing community, review feedback, and make any necessary revisions before sharing the finalized announcement in a company-wide Viva Engage community. For this training exercise, we stop short of that final step, as Viva Engage operates across your entire tenant.
 

--- a/Instructions/Labs/M06-empower-workforce-copilot-hr/09-Ex2-2-use-viva-engage-announce-agent.md
+++ b/Instructions/Labs/M06-empower-workforce-copilot-hr/09-Ex2-2-use-viva-engage-announce-agent.md
@@ -15,10 +15,7 @@ Adatum's Chief People Officer asked you to create a company-wide announcement in
 
 Perform the following steps to complete this task:
 
-1. In your Microsoft Edge browser, go to the **Microsoft 365** home page and select **Apps** in the navigation pane. In the **Apps** menu that appears, select **All apps**. Under the top section of apps in the **Apps** window, select **All apps**. In the **All apps** window, scroll down and select **Engage**.
-
-   > [!NOTE]
-   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Engage** from the list of apps that appears.
+1. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page and select the **App Launcher** (grid icon), and then select **More Apps**. From the list of apps, select **Engage**.
 
 2. In **Viva Engage**, you should begin by creating a new community for testing the Viva Engage announcement that you create later in this task. To do so, select **+ Create new** at the top of the **Viva Engage** navigation pane, and then select **Community** in the drop-down menu that appears.
 

--- a/Instructions/Labs/M06-empower-workforce-copilot-hr/10-Ex2-3-use-self-service-agent.md
+++ b/Instructions/Labs/M06-empower-workforce-copilot-hr/10-Ex2-3-use-self-service-agent.md
@@ -15,31 +15,31 @@ Adatum just announced the release of its new HR Self-Service Assistant in the co
 
 Perform the following steps to complete this task:
 
-1.  The **HR Self-Service Assistant** agent should still be open from the prior task. If not, then select the agent on the Microsoft 365 home page.
+1. The **HR Self-Service Assistant** agent should still be open from the prior task. If not, then select the agent on the **Microsoft 365 Copilot** home page.
 
-2.  Start a conversation with your HR Self-Service Assistant. Ask questions about the following topics related to relocation, such as:
+2. Start a conversation with your HR Self-Service Assistant. Ask questions about the following topics related to relocation, such as:
 
     - What relocation expenses Adatum covers
     - Whether temporary housing is provided during relocation
     - Repayment requirements if the employee leaves the company within a year of relocation
 
-3.  Ask questions related to one or more of the following topic areas:
+3. Ask questions related to one or more of the following topic areas:
 
     - Criteria and process for promotions
-    - Details of Adatum’s 401(k) matching program
+    - Details of Adatum's 401(k) matching program
     - Procedures for requesting personal or family leave
     - Educational or certification reimbursement opportunities
     - Disciplinary process or consequences for violating the Code of Conduct
     - Eligibility and expectations for remote or hybrid work arrangements
 
-4.  Observe how the agent’s responses cite or summarize information from the policy files. Evaluate the completeness and clarity of the agent’s answers. Note any policies that Adatum might need to update for better self-service accuracy.
+4. Observe how the agent’s responses cite or summarize information from the policy files. Evaluate the completeness and clarity of the agent’s answers. Note any policies that Adatum might need to update for better self-service accuracy.
 
-5.  Now ask one or more questions about HR topics that aren’t covered in the knowledge source files. For example:
+5. Now ask one or more questions about HR topics that aren’t covered in the knowledge source files. For example:
 
     - **What is the salary range for my role at Adatum, and how are annual merit increases determined?**
 
-    - **How does Adatum’s annual performance review process work, and what performance rating scale does the company use?**
+    - **How does Adatum's annual performance review process work, and what performance rating scale does the company use?**
 
 
-6.  Evaluate how the agent responds to questions that aren’t covered in the knowledge source files.
+6. Evaluate how the agent responds to questions that aren’t covered in the knowledge source files.
 

--- a/Instructions/Labs/M06-empower-workforce-copilot-hr/10-Ex2-3-use-self-service-agent.md
+++ b/Instructions/Labs/M06-empower-workforce-copilot-hr/10-Ex2-3-use-self-service-agent.md
@@ -9,9 +9,9 @@ lab:
 
 # Exercise 2, Task 3: Ask the HR self-service agent questions about HR policies
 ---
-In this task, you take on the role of an Adatum employee who was to a management position that requires relocating to Fargo, North Dakota. Before finalizing the move, you want to understand what relocation benefits Adatum provides.
+In this task, you take on the role of an Adatum employee who was promoted to a management position that requires relocating to Fargo, North Dakota. Before finalizing the move, you want to understand what relocation benefits Adatum provides.
 
-Adatum just announced the release of its new HR Self-Service Assistant in the company’s Viva Engage community page. You decide to take advantage of this new agent by seeing if it can answer your questions about company policies related to your promotion, relocation, and remote work schedule, plus any other topics that interest you.
+Adatum just announced the release of its new HR Self-Service Assistant in the company's Viva Engage community page. You decide to take advantage of this new agent by seeing if it can answer your questions about company policies related to your promotion, relocation, and remote work schedule, plus any other topics that interest you.
 
 Perform the following steps to complete this task:
 
@@ -32,14 +32,13 @@ Perform the following steps to complete this task:
     - Disciplinary process or consequences for violating the Code of Conduct
     - Eligibility and expectations for remote or hybrid work arrangements
 
-4. Observe how the agent’s responses cite or summarize information from the policy files. Evaluate the completeness and clarity of the agent’s answers. Note any policies that Adatum might need to update for better self-service accuracy.
+4. Observe how the agent's responses cite or summarize information from the policy files. Evaluate the completeness and clarity of the agent's answers. Note any policies that Adatum might need to update for better self-service accuracy.
 
-5. Now ask one or more questions about HR topics that aren’t covered in the knowledge source files. For example:
+5. Now ask one or more questions about HR topics that aren't covered in the knowledge source files. For example:
 
     - **What is the salary range for my role at Adatum, and how are annual merit increases determined?**
 
     - **How does Adatum's annual performance review process work, and what performance rating scale does the company use?**
 
-
-6. Evaluate how the agent responds to questions that aren’t covered in the knowledge source files.
+6. Evaluate how the agent responds to questions that aren't covered in the knowledge source files.
 

--- a/Instructions/Labs/M06-empower-workforce-copilot-hr/11-Ex2-4-use-researcher-agent-gather-insights.md
+++ b/Instructions/Labs/M06-empower-workforce-copilot-hr/11-Ex2-4-use-researcher-agent-gather-insights.md
@@ -9,17 +9,17 @@ lab:
 
 # Exercise 2, Task 4: Use the Researcher agent to gather employee relocation insights
 ---
-As part of your relocation to the Adatum office in Fargo, North Dakota, you want to explore what it’s like to live in Fargo and nearby communities in both North Dakota and Minnesota. You plan to use this information to help decide where your family settles. Key considerations include quality of life, housing options, commute times, recreational opportunities, community amenities, and access to strong educational programs for your children.
+As part of your relocation to the Adatum office in Fargo, North Dakota, you want to explore what it's like to live in Fargo and nearby communities in both North Dakota and Minnesota. You plan to use this information to help decide where your family settles. Key considerations include quality of life, housing options, commute times, recreational opportunities, community amenities, and access to strong educational programs for your children.
 
 You then ask Researcher to analyze the cities in which these communities are located and provide a ranking of the top areas to consider based on a combination of these factors.
 
 Perform the following steps to complete this task:
 
-1.  In your Microsoft Edge browser, you should still be in the **HR Self-Service Assistant** agent. In the list of agents in the navigation pane, select the **Researcher** agent.
+1. In your Microsoft Edge browser, you should still be in the **HR Self-Service Assistant** agent. In the list of agents in the navigation pane, select the **Researcher** agent.
 
-2.  Specify that the agent should use only **Web** sources for this query.
+2. Specify that the agent should use only **Web** sources for this query. For this, select **Sources** and then toggle off the remaining sources, leaving only **Web** selected.
 
-3.  Enter a prompt that asks the agent to create a report analyzing Fargo and all surrounding communities within a 40-mile radius in both North Dakota and Minnesota. Use the most recent data available. Rank the cities based on overall quality of life and family-friendliness, and explain key trade-offs involved. Summarize its findings in a table for easy comparison. Include factors such as:
+3. Enter a prompt that asks the agent to create a report analyzing Fargo and all surrounding communities within a 40-mile radius in both North Dakota and Minnesota. Use the most recent data available. Rank the cities based on overall quality of life and family-friendliness, and explain key trade-offs involved. Summarize its findings in a table for easy comparison. Include factors such as:
 
     - Housing market and affordability
     - Cost of living
@@ -29,9 +29,9 @@ Perform the following steps to complete this task:
     - Taxes and financial considerations
     - Commute time to Fargo
 
-4.  Review Researcher’s analysis of your request. If everything looks OK, tell it to **Go ahead**.
+4. Review Researcher's analysis of your request. If everything looks OK, tell it to **Go ahead**.
 
-5.  Review the results. Now ask Researcher to create a report about public and private high schools in Fargo and the surrounding communities within a 40-mile radius. Use the most recent data available. Rank every school, treating all criteria equally in ranking. Summarize its findings in a table for easy comparison. Include factors such as:
+5. Review the results. Now ask Researcher to create a report about public and private high schools in Fargo and the surrounding communities within a 40-mile radius. Use the most recent data available. Rank every school, treating all criteria equally in ranking. Summarize its findings in a table for easy comparison. Include factors such as:
 
     - Competitive athletic programs
     - Access to IB (International Baccalaureate) and AP (Advanced Placement) courses
@@ -40,9 +40,9 @@ Perform the following steps to complete this task:
     - Student-teacher ratios
     - Graduation rates
 
-6.  Review Researcher’s analysis of your request. If everything looks OK, tell it to **Go ahead**.
+6. Review Researcher's analysis of your request. If everything looks OK, tell it to **Go ahead**.
 
-7.  Review the results. You now want to compare how the best communities and schools align, and identify trade-offs between location and education quality. Ask Researcher to create a table that compares the top five ranked cities from your community analysis with the top five ranked schools from your school analysis. Include columns for:
+7. Review the results. You now want to compare how the best communities and schools align, and identify trade-offs between location and education quality. Ask Researcher to create a table that compares the top five ranked cities from your community analysis with the top five ranked schools from your school analysis. Include columns for:
 
     - City name
     - School name
@@ -51,4 +51,6 @@ Perform the following steps to complete this task:
     - Key highlights (affordability, amenities, academic strengths)
 
 
-8.  Review the results. As this task showed, Researcher can take even a short prompt and deliver a thorough, structured analysis using up‑to‑date web data. You can use this same capability to explore, compare, and evaluate almost any topic where research, comparison, or decision support is needed.
+8. Review the results. As this task showed, Researcher can take even a short prompt and deliver a thorough, structured analysis using up-to-date web data. You can use this same capability to explore, compare, and evaluate almost any topic where research, comparison, or decision support is needed.
+
+


### PR DESCRIPTION
## Summary

This PR brings the Module 06 (Empower your workforce with Copilot — HR) lab instructions up to Microsoft Learn style standards and corrects UI drift across the current Microsoft 365 Copilot, Agent Builder, Viva Engage, and Researcher experiences. Changes span all 11 lab files in the module, covering both Exercise 1 (manager insights) and Exercise 2 (HR self-service agent).

## Changes

### Style and typography (all files)
- Replaced curly/smart quotes and apostrophes with straight quotes throughout.
- Normalized ordered-list numbering (single space after the period) and fixed inconsistent list markup and indentation.
- Replaced inline `<br/>` tags with proper blank lines for multi-paragraph list items.
- Fixed bold markup, spacing, and smart-quote artifacts in prompts and callouts.
- Corrected minor grammar/typos (e.g., "scan improve" → "can improve", "was to a management position" → "was promoted to a management position").

### UI drift — Exercise 1
- **Excel (Tasks 1–2):** Updated Excel Copilot steps to match the current UI and Learn style.
- **Outlook (Task 3):** Updated Copilot steps so they reference **Replace** rather than the outdated "Keep it" option.
- **Loop (Task 4):** Updated Loop Copilot steps for the current UI and improved clarity.

### UI drift — Exercise 2
- **Agent Builder (Task 1):** Reworked agent-creation steps for the current Copilot UI — **Agents → Create agent** entry point, the new **Agent Builder chat pane / Configure / Preview** layout (replacing the old **Describe/Configure** tabs), the **Web search** knowledge toggle (replacing **Search all websites**), and the **+ Add knowledge** data picker (replacing **Upload from device**). Updated Microsoft 365 references to **Microsoft 365 Copilot**.
- **Viva Engage (Task 2):** Corrected navigation, app name, labels, and prompt content; fixed list numbering and the **+ Add to post** option.
- **Self-service agent (Task 3):** Fixed grammar and smart quotes in the HR agent question task and updated the Microsoft 365 Copilot home page reference.
- **Researcher (Task 4):** Added explicit guidance to scope the query to **Web** sources (select **Sources**, then toggle off all but **Web**) and tidied typography.

## Files changed

- `Instructions/Labs/M06-empower-workforce-copilot-hr/01-introduction.md` — Applied Microsoft Learn style to the HR lab introduction.
- `Instructions/Labs/M06-empower-workforce-copilot-hr/02-Ex1-introduction-manager-insights-exercise.md` — Style cleanup of the manager insights exercise intro.
- `Instructions/Labs/M06-empower-workforce-copilot-hr/03-Ex1-1-use-excel-identify-manager-metrics.md` — Updated Excel Copilot steps for UI drift and Learn style.
- `Instructions/Labs/M06-empower-workforce-copilot-hr/04-Ex1-2-use-excel-generate-manager-report.md` — Style and list-numbering fixes for the Excel report task.
- `Instructions/Labs/M06-empower-workforce-copilot-hr/05-Ex1-3-use-outlook-communicate-findings.md` — Updated Outlook Copilot steps to use **Replace** instead of "Keep it".
- `Instructions/Labs/M06-empower-workforce-copilot-hr/06-Ex1-4-use-loop-collaborative-planning.md` — Updated Loop Copilot steps for the current UI and clarity.
- `Instructions/Labs/M06-empower-workforce-copilot-hr/07-Ex2-introduction-empower-employees-exercise.md` — Style cleanup and grammar fixes in the Exercise 2 intro.
- `Instructions/Labs/M06-empower-workforce-copilot-hr/08-Ex2-1-create-self-service-agent.md` — Reworked Agent Builder steps to match the current Copilot UI.
- `Instructions/Labs/M06-empower-workforce-copilot-hr/09-Ex2-2-use-viva-engage-announce-agent.md` — Corrected Viva Engage navigation, labels, and prompt content.
- `Instructions/Labs/M06-empower-workforce-copilot-hr/10-Ex2-3-use-self-service-agent.md` — Fixed grammar and smart quotes in the HR agent question task.
- `Instructions/Labs/M06-empower-workforce-copilot-hr/11-Ex2-4-use-researcher-agent-gather-insights.md` — Added Web-source scoping guidance and cleaned up typography.
