### PR TITLE
fix folder (m07): update operations labs for Copilot UI drift and style

### DIFF
--- a/Instructions/Labs/M07-empower-workforce-copilot-operations/01-introduction.md
+++ b/Instructions/Labs/M07-empower-workforce-copilot-operations/01-introduction.md
@@ -29,10 +29,7 @@ Follow the steps below to upload all files needed to **OneDrive**:
 
 7. If prompted to **Stay signed in**, select **Don't show this again** and then **Yes**.
 
-8. In **Microsoft 365 Copilot**, select **Apps**.
-
-   > [!NOTE]
-   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **OneDrive** from the list of apps that appears.
+8. In **Microsoft 365 Copilot**, select the **App Launcher** (grid icon), and then select **More Apps**.
 
 9. Within **Apps**, select **OneDrive**.
 

--- a/Instructions/Labs/M07-empower-workforce-copilot-operations/01-introduction.md
+++ b/Instructions/Labs/M07-empower-workforce-copilot-operations/01-introduction.md
@@ -1,39 +1,54 @@
 ---
 lab:
-  title: '# Lab Setup:'
+  title: 'Lab Setup:'
   description: This training module is built around realistic, scenario‑driven exercises that reflect the responsibilities of modern Operations teams. These exercises reflect what Operations teams do daily—coordinating people, projects, safety, and change. Copilot strengthens these essential functions by reducing friction, speeding execution, and ensuring that information is accurate, consistent, and actionable.
   duration: 44 minutes
   level: 100
   islab: true
 ---
 
-# # Lab Setup:
+# Lab Setup:
 
-In this module, we'll create prompts for Microsoft 365 Copilot that reference files. First, let’s upload all required files to OneDrive to ensure they're accessible throughout the lab.
-
+In this module, we'll create prompts for Microsoft 365 Copilot that reference files. First, let's upload all required files to OneDrive to ensure they're accessible throughout the lab.
 
 ### Uploading Files to OneDrive
 
 Follow the steps below to upload all files needed to **OneDrive**:
 
 1. Log into the virtual machine provided by your tenant provider as the local **Administrator** account with the password `Pa55w.rd`.
+
 2. In the Windows taskbar, select **Microsoft Edge**.
+
 3. In the address bar, enter `https://www.office.com`.
-4. Under **Welcome to Microsoft 365**, select **Sign in**.
-5. At the **Sign-in prompt**, enter `userx@yourtenant.onmicrosoft.com` (username and tenant provided by your tenant provided) and select **Next**.
-6. At the **Enter password** screen, enter the password (provided by tenant provider) for the User account, then select **Sign in**.
+
+4. On the Microsoft 365 Copilot landing page, select **Sign in**.
+
+5. At the **Sign-in prompt**, enter `userx@yourtenant.onmicrosoft.com` (username and tenant provided by your tenant provider) and select **Next**.
+
+6. At the **Enter password** screen, enter the password (provided by your tenant provider) for the User account, then select **Sign in**.
+
 7. If prompted to **Stay signed in**, select **Don't show this again** and then **Yes**.
-8. In **Microsoft 365**, select **Apps**.
+
+8. In **Microsoft 365 Copilot**, select **Apps**.
+
+   > [!NOTE]
+   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **OneDrive** from the list of apps that appears.
+
 9. Within **Apps**, select **OneDrive**.
-10. In **OneDrive**, in the top-left corner, select **+** (add new) > **File upload**.
+
+10. In **OneDrive**, in the top-left corner, select **+ Create or upload** > **Files upload**.
+
 11. In **File Explorer**, select **This PC** > **Local Disk (C:)** and open the **ResourceFiles** folder.
+
 12. Select all files within the **ResourceFiles** folder, then select **Open** to upload them to **OneDrive**.
-13. When the upload is complete, you should see **Uploaded 29 items to My files** in the bottom center of the screen.
+
+13. When the upload is complete, you should see **Uploaded 92 items to My files** in the bottom center of the screen.
+
 14. Leave **Edge** open and move on to the next task.
 
 ### Referencing Files in Copilot
 
-When using Copilot, you may find that some files aren’t immediately available in the suggestions. This occurs because certain Copilot experiences only reference files from the **Most Recently Used (MRU)** list, while others let you browse **OneDrive** directly. To ensure a file appears in the **MRU** list, simply open it in the relevant Microsoft 365 app, and it will be added automatically.
+When using Copilot, you may find that some files aren't immediately available in the suggestions. This occurs because certain Copilot experiences only reference files from the **Most Recently Used (MRU)** list, while others let you browse **OneDrive** directly. To ensure a file appears in the **MRU** list, open it in the relevant Microsoft 365 app, and it will be added automatically.
 
 > [!IMPORTANT]
 > Microsoft 365 Copilot can only work with files saved to **OneDrive**. Files stored locally on your PC will need to be moved to **OneDrive** for Copilot to access them.
@@ -42,33 +57,32 @@ When using Copilot, you may find that some files aren’t immediately available 
 ---
 Operations teams are the backbone of every organization. They coordinate people, processes, facilities, and technology to keep the business running smoothly—often while juggling tight timelines, complex logistics, and constant change. In this environment, the ability to make fast, informed decisions is critical.
 
-Microsoft 365 Copilot is designed to help Operations professionals meet this challenge. By combining AI‑powered reasoning with the tools Operations teams already use every day, Copilot enhances productivity, reduces manual work, and enables teams to focus on higher‑value tasks such as risk mitigation, strategic planning, and cross‑functional collaboration.
+Microsoft 365 Copilot is designed to help Operations professionals meet this challenge. By combining AI-powered reasoning with the tools Operations teams already use every day, Copilot enhances productivity, reduces manual work, and enables teams to focus on higher-value tasks such as risk mitigation, strategic planning, and cross-functional collaboration.
 
-Across industries, Operations teams face similar pressures: maintaining safe and efficient facilities, coordinating multi‑team efforts, responding to unplanned disruptions, and keeping stakeholders aligned. Copilot strengthens these capabilities by helping teams:
+Across industries, Operations teams face similar pressures: maintaining safe and efficient facilities, coordinating multi-team efforts, responding to unplanned disruptions, and keeping stakeholders aligned. Copilot strengthens these capabilities by helping teams:
 
 - **Streamline planning and execution**. Copilot accelerates project planning by generating structured ideas, organizing tasks, and transforming complex information into clear outputs.
 
-- **Automate the repeatable and eliminate the tedious**. High‑volume, repetitive tasks—status updates, routine questions, review cycles, vendor communications—often consume Operations capacity. Copilot reduces that burden by automating routine communications, compiling data, and creating no‑code agents that provide consistent answers
+- **Automate the repeatable and eliminate the tedious**. High-volume, repetitive tasks—status updates, routine questions, review cycles, vendor communications—often consume Operations capacity. Copilot reduces that burden by automating routine communications, compiling data, and creating no-code agents that provide consistent answers.
 
-- **Keep complex projects on track**. Large initiatives such as facility expansions involve multiple phases, teams, timelines, and dependencies. Copilot helps visualize milestones, monitor risks, and maintain alignment. Copilot also assists with drafting communications, updating safety documentation, and generating summaries that Operations staff can act on immediately
+- **Keep complex projects on track**. Large initiatives such as facility expansions involve multiple phases, teams, timelines, and dependencies. Copilot helps visualize milestones, monitor risks, and maintain alignment. Copilot also assists with drafting communications, updating safety documentation, and generating summaries that Operations staff can act on immediately.
 
-- **Power data‑driven decisions**. Operations leaders rely on timely, accurate insights to guide actions and mitigate risks. Copilot quickly synthesizes information from documents, emails, and project notes to support informed choices.
+- **Power data-driven decisions**. Operations leaders rely on timely, accurate insights to guide actions and mitigate risks. Copilot quickly synthesizes information from documents, emails, and project notes to support informed choices.
 
-- **Strengthen communication and stakeholder alignment**. Whether briefing executives, updating frontline teams, or coordinating with vendors, clear communication is essential. Copilot helps craft concise messages, generate presentations, and compile insights from attached files.  
+- **Strengthen communication and stakeholder alignment**. Whether briefing executives, updating frontline teams, or coordinating with vendors, clear communication is essential. Copilot helps craft concise messages, generate presentations, and compile insights from attached files.
 
-This training module is built around realistic, scenario‑driven exercises that reflect the responsibilities of modern Operations teams. These exercises reflect what Operations teams do daily—coordinating people, projects, safety, and change. Copilot strengthens these essential functions by reducing friction, speeding execution, and ensuring that information is accurate, consistent, and actionable.
+This training module is built around realistic, scenario-driven exercises that reflect the responsibilities of modern Operations teams. These exercises reflect what Operations teams do daily—coordinating people, projects, safety, and change. Copilot strengthens these essential functions by reducing friction, speeding execution, and ensuring that information is accurate, consistent, and actionable.
 
 ### Copilot prompting
 
 One of the primary keys to effectively using Copilot is the quality of your Copilot prompts. A good Copilot prompt is built around the following four key elements that make your request clear, actionable, and tailored for the best results:
 
-- **Goal**. Clearly state what you want Copilot to do. For example: “Generate three to five bullet points summarizing the latest project updates.”
+- **Goal**. Clearly state what you want Copilot to do. For example: "Generate three to five bullet points summarizing the latest project updates."
 
-- **Context**. Provide background information so Copilot understands why you need this request and who or what is involved. For example: “Prepare these bullet points for a meeting with Client X about their ‘Phase 3+’ brand campaign.”
+- **Context**. Provide background information so Copilot understands why you need this request and who or what is involved. For example: "Prepare these bullet points for a meeting with Client X about their 'Phase 3+' brand campaign."
 
-- **Sources**. Specify where Copilot should look for information (documents, emails, Teams chats, and so on). For example: “Focus on emails and Teams chats since June.”
+- **Sources**. Specify where Copilot should look for information (documents, emails, Teams chats, and so on). For example: "Focus on emails and Teams chats since June."
 
-- **Expectations**. Define how you want the response delivered—tone, style, or level of detail. For example: “Use simple language so I can get up to speed quickly” or “Explain it as if I were a pirate.”
+- **Expectations**. Define how you want the response delivered—tone, style, or level of detail. For example: "Use simple language so I can get up to speed quickly" or "Explain it as if I were a pirate."
 
-
-Keep these four elements front and center as you practice creating prompts—they’re the foundation for getting clear, accurate, and useful results from Copilot. Implementing these elements as you write prompts in these exercises can build real-world skills, so writing effective prompts becomes second nature.
+Keep these four elements front and center as you practice creating prompts—they're the foundation for getting clear, accurate, and useful results from Copilot. Implementing these elements as you write prompts in these exercises can build real-world skills, so writing effective prompts becomes second nature.

--- a/Instructions/Labs/M07-empower-workforce-copilot-operations/02-Ex1-introduction-streamline-initiatives-exercise.md
+++ b/Instructions/Labs/M07-empower-workforce-copilot-operations/02-Ex1-introduction-streamline-initiatives-exercise.md
@@ -12,7 +12,7 @@ lab:
 
 # Exercise 1: Streamline operational initiatives using Microsoft 365 Copilot
 ---
-In today’s fast-paced business environment, Operations teams are expected to drive efficiency, adapt quickly, and deliver results across a wide range of initiatives. Microsoft 365 Copilot empowers Operational personnel to meet these demands by seamlessly integrating intelligent automation into everyday workflows.
+In today's fast-paced business environment, Operations teams are expected to drive efficiency, adapt quickly, and deliver results across a wide range of initiatives. Microsoft 365 Copilot empowers Operational personnel to meet these demands by seamlessly integrating intelligent automation into everyday workflows.
 
 With Copilot, Operations professionals can:
 
@@ -24,19 +24,19 @@ With Copilot, Operations professionals can:
 
 - **Streamline decision-making and stakeholder engagement** using Microsoft 365 Copilot Chat to consolidate data, draft communications, and prepare vendor outreach—all within the Microsoft 365 ecosystem.
 
-By utilizing Copilot’s capabilities across Microsoft Office apps, Operations teams can unify their approach to project ideation, analysis, and action. The result is a more agile, informed, and collaborative Operations function—one that harnesses intelligent automation to optimize outcomes and drive operational excellence.
+By utilizing Copilot's capabilities across Microsoft Office apps, Operations teams can unify their approach to project ideation, analysis, and action. The result is a more agile, informed, and collaborative Operations function—one that harnesses intelligent automation to optimize outcomes and drive operational excellence.
 
 ### Scenario
 
-Adatum Corporation’s 50‑year‑old office building has a failing boiler. As the company’s Operations Manager, you must evaluate whether to repair or replace the boiler system—and if replacing, whether to convert from a boiler to a furnace system. Your goal is to use Microsoft 365 Copilot to help you move from brainstorming to research to executive communication to decision and vendor engagement, all in a single day’s workflow.
+Adatum Corporation's 50-year-old office building has a failing boiler. As the company's Operations Manager, you must evaluate whether to repair or replace the boiler system—and if replacing, whether to convert from a boiler to a furnace system. Your goal is to use Microsoft 365 Copilot to help you move from brainstorming to research to executive communication to decision and vendor engagement, all in a single day's workflow.
 
 This workflow is reflected in the following tasks that you plan to complete this day:
 
-- **Morning: Ideate and organize using Copilot in Whiteboard**. You want to use Copilot in Whiteboard to brainstorm the installation project. Copilot generates “sticky‑note” ideas and helps you categorize them into themes (for example, project plan steps, risk mitigation, and downtime minimization), just like a facilitated sticky‑note session—only virtual.
+- **Morning: Ideate and organize using Copilot in Whiteboard**. You want to use Copilot in Whiteboard to brainstorm the installation project. Copilot generates "sticky-note" ideas and helps you categorize them into themes (for example, project plan steps, risk mitigation, and downtime minimization), just like a facilitated sticky-note session—only virtual.
 
-- **Mid‑morning: Research and document using Copilot in Word**. You shift to Word to have Copilot generate a comparative report (boiler vs. furnace).
+- **Mid-morning: Research and document using Copilot in Word**. You shift to Word to have Copilot generate a comparative report (boiler vs. furnace).
 
-- **Early afternoon: Communicate and persuade using Copilot in PowerPoint**. With the comparative report saved to OneDrive, you use Copilot in PowerPoint to turn the report into an executive presentation, refine topics before generating slides, add speaker notes, insert supporting images, and create a Q\\&A slide for stakeholder dialogue.
+- **Early afternoon: Communicate and persuade using Copilot in PowerPoint**. With the comparative report saved to OneDrive, you use Copilot in PowerPoint to turn the report into an executive presentation, refine topics before generating slides, add speaker notes, insert supporting images, and create a Q&A slide for stakeholder dialogue.
 
 - **Late afternoon: Decide and engage using Microsoft 365 Copilot Chat**. You close the loop by using Copilot Chat to synthesize everything produced so far, frame a request for proposal (RFP), and prepare for vendor engagement and leadership decision.
 

--- a/Instructions/Labs/M07-empower-workforce-copilot-operations/03-Ex1-1-use-whiteboard-brainstorm-ideas.md
+++ b/Instructions/Labs/M07-empower-workforce-copilot-operations/03-Ex1-1-use-whiteboard-brainstorm-ideas.md
@@ -17,91 +17,102 @@ Well, that's really what this task is - just a virtualized sticky-note exercise,
 
 Perform the following steps to complete this task:
 
-1.  In your Microsoft Edge browser, sign in to the **Microsoft 365** home page **(https://www.microsoft365.com)** and select the **Apps** icon in the navigation pane. In the **Apps** menu that appears, select **All apps**. Under the top section of apps in the **Apps** window, select **All apps→**. In the **All apps** window, scroll down and select **Whiteboard**.
-
-2.  In **Whiteboard for the web**, start a new Whiteboard session.
-
-3.  The **Board name** for this session defaults to **Whiteboard X** (where X is a number). Select this field and change the **Board name** to **Boiler installation project plan**.
-
-4.  Select the **Copilot** icon next to the menu bar at the bottom of the page and select **Suggest** from the menu that appears.
-
-5.  In the **Suggest content with Copilot** window, ask Copilot in Whiteboard to suggest the steps that Adatum should follow when installing a new boiler system.
+1. In your Microsoft Edge browser, sign in to the **Microsoft 365 Copilot** home page  [**https://m365.cloud.microsoft.com**](https://m365.cloud.microsoft.com) and select the **Apps** icon in the navigation pane. In the **Apps** menu that appears, select **All apps**. Under the top section of apps in the **Apps** window, select **All apps→**. In the **All apps** window, scroll down and select **Whiteboard**.
 
    > [!NOTE]
-   > For this first prompt, we’ve provided the text so you can see what an effective prompt looks like when it incorporates the four key elements discussed in the Introduction unit. You must write all remaining prompts in this exercise, but in doing so, you can use this prompt as a model to emulate.
+   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Whiteboard** from the list of apps that appears.
+
+2. In **Whiteboard for the web**, select **+ New Whiteboard** to start a new Whiteboard session.
+
+3. The **Board name** for this session may default to **Whiteboard X** (where X is a number). Select this field and change the **Board name** to **Boiler installation project plan**.
+
+4. Select the **Copilot** icon next to the menu bar at the bottom of the page and select **Suggest** from the menu that appears.
+
+5. In the **Suggest content with Copilot** window, ask Copilot in Whiteboard to suggest the steps that Adatum should follow when installing a new boiler system. You can submit the following prompt:
+
+   > [!NOTE]
+   > For this first prompt, we've provided the text so you can see what an effective prompt looks like when it incorporates the four key elements discussed in the Introduction unit. You must write all remaining prompts in this exercise, but in doing so, you can use this prompt as a model to emulate.
     
    **I'm the Operations Manager at Adatum Corporation. Our 50-year-old office building has a failing boiler, and I need to evaluate options for repair or replacement. Before starting the installation process, I want to brainstorm and organize the typical steps companies should follow when installing a new boiler system. Using your expertise, please suggest a comprehensive list of actionable steps for a successful boiler installation project.**
 
-6.  If the **Suggest content with Copilot** window displays an error message indicating that "**Something went wrong. Please try again.**" or "**Copilot couldn't process this prompt. Please rephrase it.**" then shorten the prompt. For example, enter:  
-    <br/>**I'm the Operations Manager for Adatum Corporation. We're installing a new boiler in our company’s heating system. Please suggest the steps we should follow to install the new boiler**.  
+6. If the **Suggest content with Copilot** window displays an error message indicating that "**Something went wrong. Please try again.**" or "**Copilot couldn't process this prompt. Please rephrase it.**" then shorten the prompt. For example, enter:  
     
-7.  If the **Suggest content with Copilot** window displays the same error, then shorten the prompt to its bare minimum. For example, enter:  
-    <br/>**Create a list of the steps that a company should take to install a new boiler heating system.**
+    **I'm the Operations Manager for Adatum Corporation. We're installing a new boiler in our company's heating system. Please suggest the steps we should follow to install the new boiler**.  
+    
+7. If the **Suggest content with Copilot** window displays the same error, then shorten the prompt to its bare minimum. For example, enter:  
+    
+    **Create a list of the steps that a company should take to install a new boiler heating system.**
 
    > [!TIP]
    > Sometimes, Copilot works best with direct, single-action prompts. Once you get a response, you can build on it with follow-up requests.
 
-8.  By default, Copilot in Whiteboard generates ideas in groups of six. In the **Suggest content with Copilot** window that appears, note the first six ideas that it generated. Copilot gives you two options here. You can either attach the ideas to your whiteboard if you're satisfied with the suggestions, or you can have Copilot generate more suggestions. Notice how the **Insert (6)** button indicates the number of ideas that Copilot generated, which in this case is six. 
-    <br/><br/>While six suggestions are a good starting point, you want to dig deeper into the tasks needed to install the boiler system, so select the **Generate more** button. Note how Copilot generated another six ideas, so now the button displays **Insert (12)**. While you can keep generating more ideas, for the sake of time, let's insert the 12 ideas currently presented. Select the **Insert (12)** button.
+8. By default, Copilot in Whiteboard generates ideas in groups of six. In the **Suggest content with Copilot** window that appears, note the first six ideas that it generated. Copilot gives you two options here. You can either attach the ideas to your whiteboard if you're satisfied with the suggestions, or you can have Copilot generate more suggestions. Notice how the **Insert (6)** button indicates the number of ideas that Copilot generated, which in this case is six. 
+    
+    While six suggestions are a good starting point, you want to dig deeper into the tasks needed to install the boiler system, so select the **Generate more** button. Note how Copilot generated another six ideas, so now the button displays **Insert (12)**. While you can keep generating more ideas, for the sake of time, let's insert the 12 ideas currently presented. Select the **Insert (12)** button.
 
-9.  Notice how Copilot attaches the suggested ideas to your whiteboard in the form of yellow sticky notes. As with a real-world brainstorming session involving actual sticky notes, you can edit a particular note, delete it, lock it from future removal, and so on. In Microsoft Whiteboard, these activities are supported through standard whiteboarding functionality. 
-    <br/><br/>If you haven't used Whiteboard before, try selecting (double-click) a specific note, and then in the menu bar that appears above it, you can select the **Edit text** (pencil) icon or any of the other options. Selecting the ellipsis icon at the end of the menu bar displays a menu of more options, such as deleting the note. Again, the idea behind Microsoft Whiteboard is to mimic real-world sticky-note exercises. Feel free to edit any note as you wish.
+9. Notice how Copilot attaches the suggested ideas to your whiteboard in the form of yellow sticky notes. As with a real-world brainstorming session involving actual sticky notes, you can edit a particular note, delete it, lock it from future removal, and so on. In Microsoft Whiteboard, these activities are supported through standard whiteboarding functionality. 
+    
+    If you haven't used Whiteboard before, try selecting (double-click) a specific note, and then in the menu bar that appears above it, you can select the **Edit text** (pencil) icon or any of the other options. Selecting the ellipsis icon at the end of the menu bar displays a menu of more options, such as deleting the note. Again, the idea behind Microsoft Whiteboard is to mimic real-world sticky-note exercises. Feel free to edit any note as you wish.
 
-10.  In looking at the suggested ideas, you feel they don't cover risk mitigation adequately. Select the **Copilot** icon at the bottom of the page and then select **Suggest** from the menu.
+10. In looking at the suggested ideas, you feel they don't cover risk mitigation adequately. Select the **Copilot** icon at the bottom of the page and then select **Suggest** from the menu.
 
-11.  In the **Suggest content with Copilot** window that appears, ask Copilot to suggest ways to mitigate the risks of installing a new boiler into the building's heating system.
+11. In the **Suggest content with Copilot** window that appears, ask Copilot to suggest ways to mitigate the risks of installing a new boiler into the building's heating system.
 
-12.  Generate 12 risk mitigation ideas and then insert them into the Whiteboard. Note how the block of 12 notes is highlighted with a line around the block. This block of notes is known as a note grid. You can move or resize a note grid just like any other element on your whiteboard. 
-    <br/><br/>As you resize a note grid, the sizes of all the sticky notes inside it adjust accordingly. If the block of 12 notes overlays on top of one of the existing blocks of notes, select one of the outside lines around the note grid and drag the entire block of 12 notes to the side so that it doesn't overlay any of the previous notes. 
-    <br/><br/>If you run out of space on the screen and part of the block falls off the screen, select the **Fit to Screen** icon on the bottom-right corner of the page to display all the notes on the screen (the **Fit to screen** icon appears when a block is partially off the screen). You might need to select the icon more than once to fit the content onto the screen.
+12. Generate 12 risk mitigation ideas and then insert them into the Whiteboard. Note how the block of 12 notes is highlighted with a line around the block. This block of notes is known as a note grid. You can move or resize a note grid just like any other element on your whiteboard. 
+    
+    As you resize a note grid, the sizes of all the sticky notes inside it adjust accordingly. If the block of 12 notes overlays on top of one of the existing blocks of notes, select one of the outside lines around the note grid and drag the entire block of 12 notes to the side so that it doesn't overlay any of the previous notes. 
+    
+    If you run out of space on the screen and part of the block falls off the screen, select the **Fit to Screen** icon on the bottom-right corner of the page to display all the notes on the screen (the **Fit to screen** icon appears when a block is partially off the screen). You might need to select the icon more than once to fit the content onto the screen.
 
-13.  You now have 24 suggestions. Feel free to select any of the suggestions and edit them as you wish.
+13. You now have 24 suggestions. Feel free to select any of the suggestions and edit them as you wish.
 
-14.  At this point, you completed all the edits that you want done to the notes. You now want Copilot to organize the notes by category. When you categorize the notes, Copilot determines the names of the categories and automatically organizes the notes accordingly.
+14. At this point, you completed all the edits that you want done to the notes. You now want Copilot to organize the notes by category. When you categorize the notes, Copilot determines the names of the categories and automatically organizes the notes accordingly.
 
    > [!WARNING]
-   > When you choose the option to categorize your notes, Whiteboard automatically selects the sticky notes that are currently in view on the canvas. It displays the selected notes within a border. Notes outside the current viewport aren’t included within this border, so if you proceed immediately, those notes that are outside the border aren’t categorized.
+   > When you choose the option to categorize your notes, Whiteboard automatically selects the sticky notes that are currently in view on the canvas. It displays the selected notes within a border. Notes outside the current viewport aren't included within this border, so if you proceed immediately, those notes that are outside the border aren't categorized.
 
-15.  There are two ways to expand the selection so that all notes are included within the border:
+15. There are two ways to expand the selection so that all notes are included within the border:
     
-        - **Show more notes on the screen**. When you select the Copilot option to categorize notes, Copilot grabs everything that’s in view and places them within the border. To avoid the situation where Copilot doesn’t include all the notes within the border, zoom out or pan until all the notes you want are visible.
+    - **Show more notes on the screen**. When you select the Copilot option to categorize notes, Copilot grabs everything that's in view and places them within the border. To avoid the situation where Copilot doesn't include all the notes within the border, zoom out or pan until all the notes you want are visible.
     
-        - **Select everything explicitly using a keyboard command**. Press **Ctrl+A** to select all objects on the canvas, including sticky notes that aren't in view. Select one of the edges of the border and drag the entire selection of notes into the view on the canvas so that you can see all the notes.
+    - **Select everything explicitly using a keyboard command**. Press **Ctrl+A** to select all objects on the canvas, including sticky notes that aren't in view. Select one of the edges of the border and drag the entire selection of notes into the view on the canvas so that you can see all the notes.
   
-        For this task, select **Ctrl+A** to select all the notes.  
+    For this task, select **Ctrl+A** to select all the notes.  
 
-16.  Note how Copilot selected all the sticky notes, even ones that weren’t currently in view on the canvas. If some of the notes aren’t fully in view on the canvas, select one of the edges of the border and drag the entire selection into the canvas so that you can see all the notes.
+16. Note how Copilot selected all the sticky notes, even ones that weren't currently in view on the canvas. If some of the notes aren't fully in view on the canvas, select one of the edges of the border and drag the entire selection into the canvas so that you can see all the notes.
 
-17.  With all the notes now appearing within view on the canvas, select the **Copilot** icon on the bottom of the window and select the **Categorize** option in the menu. Doing so displays a **Categorize selected notes** window. Select the **Categorize** button that appears in this window.
+17. With all the notes now appearing within view on the canvas, select the **Copilot** icon on the bottom of the window and select the **Categorize** option in the menu. Doing so displays a **Categorize selected notes?** window. Select the **Categorize** button that appears in this window.
 
-18.  Note what happened. Copilot generated a set of categories and reorganized the notes accordingly. It also assigned each category of notes a different color to help identify the differences between categories. 
-    <br/><br/>Sometimes the rectangle containing the notes is small and hard to read. If this situation occurs, select the **Fit to Screen** icon on the bottom-right corner of the page. You can select this icon multiple times until the image is large enough to read, but not too large that it exceeds the size of the screen.
+18. Note what happened. Copilot generated a set of categories and reorganized the notes accordingly. It also assigned each category of notes a different color to help identify the differences between categories. 
+    
+    Sometimes the rectangle containing the notes is small and hard to read. If this situation occurs, select the **Fit to Screen** icon on the bottom-right corner of the page. You can select this icon multiple times until the image is large enough to read, but not too large that it exceeds the size of the screen.
 
-19.  Note the icon tray that appears below the organized group of notes. If you aren’t satisfied with the categories, select the **Regenerate** button on the icon tray.
+19. Note the icon tray that appears below the organized group of notes. If you aren't satisfied with the categories, select the **Regenerate** button on the icon tray.
 
    > [!TIP]
    > You can select the **Regenerate** button as many times as needed until you're satisfied with the categories that Copilot provides. Select this button several times and note the changes that Copilot makes each time. Besides changing category names and relocating notes, Copilot might add or reduce the number of categories with each regeneration.
 
-20.  After regenerating the categories several times, you’re not sure which iteration you liked best. While Copilot doesn’t currently support going back to a previous categorization, it does allow you to start over. Select the **Revert** button to return to the starting list of yellow sticky notes.
+20. After regenerating the categories several times, you're not sure which iteration you liked best. While Copilot doesn't currently support going back to a previous categorization, it does allow you to start over. Select the **Revert** button to return to the starting list of yellow sticky notes.
 
-21.  To categorize the sticky notes once again, select the **Copilot** icon at the bottom of the page and then select **Categorize** from the menu. In the **Categorize selected notes?** window, select the **Categorize** button.
+21. To categorize the sticky notes once again, select the **Copilot** icon at the bottom of the page and then select **Categorize** from the menu. In the **Categorize selected notes?** window, select the **Categorize** button.
 
-22.  Now that you know how the **Regenerate** button works, for the sake of time, select it once or twice if necessary until you’re satisfied with the category results.
+22. Now that you know how the **Regenerate** button works, for the sake of time, select it once or twice if necessary until you're satisfied with the category results.
 
-23.  After regenerating the categories several times, you realize that you're missing detailed steps concerning minimization of system downtime. You want to ask Copilot to add more ideas to your Whiteboard session concerning this issue. Plus, you identified a note that you want to remove. However, since you already organized your ideas, you must change your whiteboard session back into the editing mode that you were in before you categorized the notes. To do so, select the **Revert** button.
+23. After regenerating the categories several times, you realize that you're missing detailed steps concerning minimization of system downtime. You want to ask Copilot to add more ideas to your Whiteboard session concerning this issue. Plus, you identified a note that you want to remove. However, since you already organized your ideas, you must change your whiteboard session back into the editing mode that you were in before you categorized the notes. To do so, select the **Revert** button.
 
-24.  Now that you're back into editing mode, select a note that you no longer want, and then in the icon tray that appears, select the ellipsis icon. Select **Delete** from the menu that appears to delete the note.
+24. Now that you're back into editing mode, select a note that you no longer want, and then in the icon tray that appears, select the ellipsis icon. Select **Delete** from the menu that appears to delete the note.
 
-25.  Repeat the process that you performed earlier to have Copilot suggest more notes. In this case, ask Copilot to suggest ways to limit heating system downtime when installing a new boiler.
+25. Repeat the process that you performed earlier to have Copilot suggest more notes. In this case, ask Copilot to suggest ways to limit heating system downtime when installing a new boiler.
 
-26.  Review the six ideas that Copilot suggested. You're satisfied with these ideas, so insert them into your Whiteboard canvas. If the note grid containing the six new ideas overlays existing notes, drag the note grid to the side so that it doesn't overlay any of the previous notes. If you run out of space on the screen and part of the block falls off the screen, select the **Fit to Screen** icon on the bottom-right corner of the page. You might need to select the icon more than once to fit the entirety of content onto the screen.
+26. Review the six ideas that Copilot suggested. You're satisfied with these ideas, so insert them into your Whiteboard canvas. If the note grid containing the six new ideas overlays existing notes, drag the note grid to the side so that it doesn't overlay any of the previous notes. If you run out of space on the screen and part of the block falls off the screen, select the **Fit to Screen** icon on the bottom-right corner of the page. You might need to select the icon more than once to fit the entirety of content onto the screen.
 
-27.  You're ready for Copilot to organize the sticky notes. Repeat the earlier process to have Copilot categorize the notes.
+27. You're ready for Copilot to organize the sticky notes. Repeat the earlier process to have Copilot categorize the notes.
 
-28.  Review the categories. Regenerate the categories until you’re satisfied with the results. At that point, select the **Keep it** button.
+28. Review the categories. Regenerate the categories until you're satisfied with the results. At that point, select the **Keep it** button.
 
-29. Note how each category of sticky notes is a different color. You realize that you would like a short summary of the brainstorming session added to your whiteboard content. To do so, select the **Copilot** icon at the bottom of the page and then select **Summarize** from the menu. 
-    <br/><br/>In our testing, Copilot sometimes generated a short summary of the main themes from this whiteboarding session; other times, it failed to do so. Scroll down to see if Copilot generated a summary. If so, select **Keep it**.
+29. Note how each category of sticky notes is a different color. You realize that you would like a short summary of the brainstorming session added to your whiteboard content. To do so, select the **Copilot** icon at the bottom of the page and then select **Summarize** from the menu.
+    
+    In our testing, Copilot sometimes generated a short summary of the main themes from this whiteboarding session; other times, it failed to do so. Scroll down to see if Copilot generated a summary. If so, select **Keep it**.
 
 30. Select the **Fit to Screen** icon on the bottom-right corner of the page to fit all the sticky notes and the session summary onto the entire screen.
 

--- a/Instructions/Labs/M07-empower-workforce-copilot-operations/03-Ex1-1-use-whiteboard-brainstorm-ideas.md
+++ b/Instructions/Labs/M07-empower-workforce-copilot-operations/03-Ex1-1-use-whiteboard-brainstorm-ideas.md
@@ -17,10 +17,7 @@ Well, that's really what this task is - just a virtualized sticky-note exercise,
 
 Perform the following steps to complete this task:
 
-1. In your Microsoft Edge browser, sign in to the **Microsoft 365 Copilot** home page  [**https://m365.cloud.microsoft.com**](https://m365.cloud.microsoft.com) and select the **Apps** icon in the navigation pane. In the **Apps** menu that appears, select **All apps**. Under the top section of apps in the **Apps** window, select **All apps→**. In the **All apps** window, scroll down and select **Whiteboard**.
-
-   > [!NOTE]
-   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Whiteboard** from the list of apps that appears.
+1. In your Microsoft Edge browser, sign in to the **Microsoft 365 Copilot** home page  [**https://m365.cloud.microsoft.com**](https://m365.cloud.microsoft.com), select the **App Launcher** (grid icon), and then select **More Apps**. From the list of apps, select **Whiteboard**.
 
 2. In **Whiteboard for the web**, select **+ New Whiteboard** to start a new Whiteboard session.
 

--- a/Instructions/Labs/M07-empower-workforce-copilot-operations/04-Ex1-2-use-word-compare-reports.md
+++ b/Instructions/Labs/M07-empower-workforce-copilot-operations/04-Ex1-2-use-word-compare-reports.md
@@ -9,29 +9,32 @@ lab:
 
 # Exercise 1, Task 2: Use Copilot in Word to compare operational reports
 ---
-As the Operations Manager at Adatum Corporation, you discovered the current boiler system that heats the company's 50-year-old office building needs significant repair, if not outright replacement. You feel that this situation might be the opportune time to convert your heating system from the existing boiler system to a more energy-efficient furnace system. However, you aren’t familiar with the differences between the two types of heating systems. As such, you want to investigate the situation and create a report that you can present to management.
+As the Operations Manager at Adatum Corporation, you discovered the current boiler system that heats the company's 50-year-old office building needs significant repair, if not outright replacement. You feel that this situation might be the opportune time to convert your heating system from the existing boiler system to a more energy-efficient furnace system. However, you aren't familiar with the differences between the two types of heating systems. As such, you want to investigate the situation and create a report that you can present to management.
 
-Since you want to create a report using public web data (in this case, related to heating systems), you naturally think of using Microsoft 365 Word. You heard that Copilot in Word can generate reports for you, so you want to take this opportunity to not only create your report, but also investigate Copilot's reporting features. 
+Since you want to create a report using public web data (in this case, related to heating systems), you naturally think of using Microsoft 365 Word. You heard that Copilot in Word can generate reports for you, so you want to take this opportunity to not only create your report, but also investigate Copilot's reporting features.
 
 #### Using Copilot in Word  
 
 Copilot in Word can behave in two different ways, depending on whether **Edit with Copilot** is enabled. Understanding this distinction is important, because it affects whether Copilot can automatically apply changes to your document or just provide suggestions for you to use.
 
-When **Edit with Copilot** is enabled, Copilot acts as an in-document author and editor. You can ask Copilot to create a document from scratch, rewrite sections, add summaries, or refine language—and it can apply those changes directly to the document, typically with your confirmation. In this experience, Copilot behaves like a collaborative writing partner that can both generate and revise content without requiring manual copy and paste. This is commonly the experience when prompting Copilot from within a Word document, such as using the drafting prompt above a blank document or the prompt field in the Copilot pane.
+When **Edit with Copilot** is enabled, Copilot acts as an in-document author and editor. You can ask Copilot to create a document from scratch, rewrite sections, add summaries, or refine language, and it can apply those changes directly to the document, typically with your confirmation. In this experience, Copilot behaves like a collaborative writing partner that can both generate and revise content without requiring manual copy and paste. This is commonly the experience when prompting Copilot from within a Word document, such as using the drafting prompt above a blank document or the prompt field in the Copilot pane.
 
-When **Edit with Copilot** is disabled, Copilot behaves more like Copilot Chat. It can still research topics, summarize information, and draft text, but it doesn’t automatically modify the document. Instead, responses appear in the Copilot pane, and you decide what—if anything—gets added to the document. This approach is useful when you want Copilot to act as a research assistant or idea generator while maintaining full control over what content is inserted.
+When **Edit with Copilot** is disabled, Copilot behaves more like Copilot Chat. It can still research topics, summarize information, and draft text, but it doesn't automatically modify the document. Instead, responses appear in the Copilot pane, and you decide what, if anything, gets added to the document. This approach is useful when you want Copilot to act as a research assistant or idea generator while maintaining full control over what content is inserted.
 
-In this lab, you use both approaches to see how Copilot’s behavior changes. You learn when it makes sense to let Copilot write and edit directly in your document, and when it’s better to use Copilot for research and drafting without automatic changes.
+In this lab, you use both approaches to see how Copilot's behavior changes. You learn when it makes sense to let Copilot write and edit directly in your document, and when it's better to use Copilot for research and drafting without automatic changes.
 
 Perform the following steps to complete this task:
 
-1.  In your Microsoft Edge browser, go to the **Microsoft 365** home page, select **Apps** in the navigation pane, and then select **Word** from the **Apps** menu.
+1. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page, select **Apps** in the navigation pane, and then select **Word** from the **Apps** menu.
 
-2.  In **Word for the web**, create a blank document.
+   > [!NOTE]
+   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Word** from the list of apps that appears.
 
-3.  On the **Home** tab ribbon, select **Copilot**. In the Copilot pane, verify the **Edit with Copilot** icon appears in the prompt field next to the plus (+) sign. If you don’t see it, select the plus sign and then select **Edit with Copilot** in the drop-down menu. The icon should now appear in the prompt field.
+2. In **Word for the web**, create a blank document.
 
-4.  In the prompt field, tell Copilot that you’re the Operations Manager for Adatum Corporation, and that you’re thinking about possibly replacing your building's current boiler system with a furnace system. Ask it to generate a report based on publicly available information that describes what type of boiler systems are used in most commercial buildings. The report should also include:
+3. In the bottom-right corner of the Word document, select the **Copilot** icon to open the Copilot pane. Verify the pane opens in edit mode. The heading should read **Let's edit your document**, and the prompt field should display the placeholder text **Describe what you'd like to edit**. Below the heading, confirm that the mode selector is set to **Allow editing** (so Copilot can edit your document directly). If it shows **Chat only**, select the drop-down and then select **Allow editing**.
+
+4. In the prompt field, tell Copilot that you're the Operations Manager for Adatum Corporation, and that you're thinking about possibly replacing your building's current boiler system with a furnace system. Ask it to generate a report based on publicly available information that describes what type of boiler systems are used in most commercial buildings. The report should also include:
 
     - An overview of each system, including energy efficiency considerations, maintenance requirements, and a high-level cost comparison.
 
@@ -41,19 +44,20 @@ Perform the following steps to complete this task:
 
     - Whether changing from a boiler system to a furnace system can affect the current air conditioning system.
 
-    - The average defect rates for boiler systems versus furnace systems.  
-        
-5.  Review the report that Copilot generated. Note the level of detail in each area of interest.
+    - The average defect rates for boiler systems versus furnace systems.
 
-6.  Now let’s use **Edit in Copilot** to update the document. In the prompt field, ask Copilot to revise the report to make it more suitable for a C-suite executive audience.
+5. Review the report that Copilot generated. Note the level of detail in each area of interest.
 
-7.  Review the results. Note how Copilot applied the revisions directly to the document. You don't have to manually copy and paste the results because Copilot behaves like an in-document editor and writer when **Edit in Copilot** is enabled.
+6. Now let's use **Edit in Copilot** to update the document. In the prompt field, ask Copilot to revise the report to make it more suitable for a C-suite executive audience.
 
-8.  Now let’s disable **Edit in Copilot** to see how Copilot’s behavior changes. In the prompt field, select the **Edit in Copilot** icon to disable it. The icon should disappear from the prompt field.
+7. Review the results. Note how Copilot applied the revisions directly to the document. You don't have to manually copy and paste the results because Copilot behaves like an in-document editor and writer when **Edit in Copilot** is enabled.
 
-9.  In the prompt field, ask Copilot to summarize the key differences between boiler systems and furnace systems for commercial buildings. Focus on efficiency, maintenance, lifespan, and typical use cases.
+8. Now, switch Copilot to chat-only mode to see how its behavior changes. In the prompt field, select the **Edit** drop-down, and then select **Chat only**.
 
-10. Note the difference in Copilot’s response. With **Edit in Copilot** disabled, Copilot operates in chat mode and doesn’t automatically update the document. Instead, it displays the results in the Copilot pane and provides you with suggestions on what you might want it to do next. Copilot also provides several icons that you can choose from, such as **Add to doc** and **Copy response**. The **Add to doc** icon lets you preview the results and then decide whether you want to insert the content into the open document. 
-<br/><br/>For this example, select the ellipsis (**More actions**) icon, which is the final icon in the list. Then select the **Export to Word** option that appears in the drop-down menu.  
+9. In the prompt field, ask Copilot to summarize the key differences between boiler systems and furnace systems for commercial buildings. Focus on efficiency, maintenance, lifespan, and typical use cases.
 
-11.  When Copilot Chat exports its results to Word, it opens **Word for the web** in another browser tab, and it copies in the content from the Copilot pane. Keep in mind, however, that it also includes the extraneous text that appears at the start and end of your chat session for this prompt. You should remove this extraneous text before saving the document.
+10. Note the difference in Copilot's response. With **Edit in Copilot** disabled, Copilot operates in chat mode and doesn't automatically update the document. Instead, it displays the results in the Copilot pane and provides you with suggestions on what you might want it to do next. Copilot also provides several icons that you can choose from, such as **Add to doc** and **Copy response**. The **Add to doc** icon lets you preview the results and then decide whether you want to insert the content into the open document. 
+
+    For this example, select the ellipsis (**More options**) icon, which is the final icon in the list. Then select the **Export to Word** option that appears in the drop-down menu.
+
+11. When Copilot Chat exports its results to Word, select **Open Word**. It opens **Word for the web** in another browser tab, and it copies in the content from the Copilot pane. Keep in mind, however, that it also includes the extraneous text that appears at the start and end of your chat session for this prompt. You should remove this extraneous text before saving the document.

--- a/Instructions/Labs/M07-empower-workforce-copilot-operations/04-Ex1-2-use-word-compare-reports.md
+++ b/Instructions/Labs/M07-empower-workforce-copilot-operations/04-Ex1-2-use-word-compare-reports.md
@@ -25,10 +25,7 @@ In this lab, you use both approaches to see how Copilot's behavior changes. You 
 
 Perform the following steps to complete this task:
 
-1. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page, select **Apps** in the navigation pane, and then select **Word** from the **Apps** menu.
-
-   > [!NOTE]
-   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Word** from the list of apps that appears.
+1. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page, select the **App Launcher** (grid icon), and then select **More Apps**. From the list of apps, select **Word**.
 
 2. In **Word for the web**, create a blank document.
 

--- a/Instructions/Labs/M07-empower-workforce-copilot-operations/05-Ex1-3-use-powerpoint-create-presentation.md
+++ b/Instructions/Labs/M07-empower-workforce-copilot-operations/05-Ex1-3-use-powerpoint-create-presentation.md
@@ -23,10 +23,7 @@ In summary, use chat-style Copilot for thinking and generating ideas; use **Edit
 
 Perform the following steps to complete this task:
 
-1. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page, select **Apps** in the navigation pane, and then select **PowerPoint** from the **Apps** menu.
-
-   > [!NOTE]
-   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **PowerPoint** from the list of apps that appears.
+1. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page, select the **App Launcher** (grid icon), and then select **More Apps**. From the list of apps, select **PowerPoint**.
 
 2. In **PowerPoint for the web**, create a blank presentation.
 

--- a/Instructions/Labs/M07-empower-workforce-copilot-operations/05-Ex1-3-use-powerpoint-create-presentation.md
+++ b/Instructions/Labs/M07-empower-workforce-copilot-operations/05-Ex1-3-use-powerpoint-create-presentation.md
@@ -13,33 +13,36 @@ In the prior task, you used Copilot in Word to create the **Heating System Compa
 
 #### Using Copilot in PowerPoint
 
-PowerPoint provides two ways to use Copilot: standard Copilot prompts for quickly generating slide content or summaries, and **Edit with Copilot** in the Copilot pane for making direct, in‑place edits to slides, layouts, and presentation structure.
+PowerPoint provides two ways to use Copilot: standard Copilot prompts for quickly generating slide content or summaries, and **Edit with Copilot** in the Copilot pane for making direct, in-place edits to slides, layouts, and presentation structure.
 
-- You should use Copilot’s standard prompts in PowerPoint when you want to draft slides quickly, summarize content, or generate speaker notes without changing the structure of the deck. When using the Copilot pane, if you enter a prompt without selecting **Edit with Copilot**, Copilot responds in a chat‑style mode that generates suggestions or content separately, rather than making direct, in‑place changes to the presentation.  
-    
-- You should use **Edit with Copilot** when you want Copilot to work directly in the presentation—such as reorganizing slides, refining slide text, improving layouts, or making iterative edits across multiple slides. **Edit with Copilot** is optimized for in‑place presentation work, so it understands slide structure and can apply changes directly to the deck, rather than just suggesting content in a separate response.
+- You should use Copilot's standard prompts in PowerPoint when you want to draft slides quickly, summarize content, or generate speaker notes without changing the structure of the deck. When using the Copilot pane, if you enter a prompt without selecting **Edit with Copilot**, Copilot responds in a chat-style mode that generates suggestions or content separately, rather than making direct, in-place changes to the presentation.
 
-In summary, use chat‑style Copilot for thinking and generating ideas; use **Edit with Copilot** for hands‑on editing inside the file. Copilot typically previews slide or layout changes and, once you confirm, it applies those changes directly to the slide deck rather than expecting the user to explicitly apply them through copy and paste.
+- You should use **Edit with Copilot** when you want Copilot to work directly in the presentation, such as reorganizing slides, refining slide text, improving layouts, or making iterative edits across multiple slides. **Edit with Copilot** is optimized for in-place presentation work, so it understands slide structure and can apply changes directly to the deck, rather than just suggesting content in a separate response.
+
+In summary, use chat-style Copilot for thinking and generating ideas; use **Edit with Copilot** for hands-on editing inside the file. Copilot typically previews slide or layout changes and, once you confirm, it applies those changes directly to the slide deck rather than expecting the user to explicitly apply them through copy and paste.
 
 Perform the following steps to complete this task:
 
-1.  In your Microsoft Edge browser, go to the **Microsoft 365** home page, select **Apps** in the navigation pane, and then select **PowerPoint** from the **Apps** menu.
+1. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page, select **Apps** in the navigation pane, and then select **PowerPoint** from the **Apps** menu.
 
-2.  In **PowerPoint for the web**, create a blank presentation.
+   > [!NOTE]
+   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **PowerPoint** from the list of apps that appears.
 
-3.  Select the **Home** tab if the **Home** tab ribbon doesn’t appear. Then select **Copilot** at the end of the **Home** tab ribbon.
+2. In **PowerPoint for the web**, create a blank presentation.
 
-4.  In the Copilot pane, select the plus (+) sign in the prompt field and then select **Add work content** in the drop-down menu. Attach the **Heating System Comparison** report that you stored in your OneDrive account in the prior task.
+3. Select the **Copilot** icon in the bottom-right corner of the PowerPoint window to open the Copilot pane.
 
-5.  Verify the **Edit with Copilot** icon appears next to the plus (+) sign in the prompt field. If you don’t see it, select the plus sign and then select **Edit with Copilot** in the drop-down menu. The icon should now appear in the prompt field.
+4. In the Copilot pane, select the **(+)** (plus) sign below the prompt field to open the **Add work content** file picker. Search for and select the **Heating System Comparison** report that you stored in your OneDrive account in the prior task.
 
-6.  In the Copilot prompt, ask Copilot to generate an executive leadership presentation based on the attached file.
+5. Verify the dropdown above the prompt field is set to **Allow editing**. This ensures Copilot can make direct, in-place edits to the presentation. If you see **Chat only** selected, select the dropdown and choose **Allow editing**.
 
-7.  If Copilot asks a series of questions related to the presentation, select the answers that you want it to apply. Select the **Confirm** button once you finish answering the questions. It might also ask a second series of questions, one of which might be to select a slide template. Keep in mind that if you don’t select a template, Copilot simply presents text on plain white slides. Again, select the answers that you want it to apply, or select **Skip all** if you want Copilot to use its best judgment.
+6. In the Copilot prompt, ask Copilot to generate an executive leadership presentation based on the attached file.
 
-8.  Copilot in PowerPoint uses this information to generate a list of slides, which might take a few minutes.
+7. If Copilot asks a series of questions related to the presentation, select the answers that you want it to apply. Select the **Confirm** button once you finish answering the questions. It might also ask a second series of questions, one of which might be to select a slide template. Keep in mind that if you don't select a template, Copilot presents text on plain white slides. Again, select the answers that you want it to apply, or select **Skip all** if you want Copilot to use its best judgment.
 
-9.  During our testing, we experienced different results with regard to slide generation. Copilot sometimes generated the slides automatically, with no further confirmation needed. Other times, it provided an outline of the slides in the Copilot chat pane, and it suggested several options as to how it could proceed. If you experience the latter scenario, tell it to proceed with the outline. In either case, it typically took several minutes for Copilot to generate the slides.
+8. Copilot in PowerPoint uses this information to generate a list of slides. Wait for the slides to generate, which might take a few minutes.
+
+9. During our testing, we experienced different results with regard to slide generation. Copilot sometimes generated the slides automatically, with no further confirmation needed. Other times, it provided an outline of the slides in the Copilot chat pane, and it suggested several options as to how it could proceed. If you experience the latter scenario, tell it to proceed with the outline. In either case, it typically took several minutes for Copilot to generate the slides.
 
 10. If Copilot suggests various options that it can apply, feel free to accept any that you wish. When you're happy with the suggested presentation, tell Copilot to proceed with slide generation.
 
@@ -47,10 +50,10 @@ Perform the following steps to complete this task:
 
 12. It might take a minute or two, but eventually Copilot should generate an image and add it to the slide.
 
-13. You also notice that there isn't any content in the presentation related to the expected lifespan for each type of heating system. Ask Copilot to research the expected lifespan of boiler heating systems versus furnace heating systems and then add it to a new slide. Before you submit this prompt, select in the slide list where you want the new slide to appear. A red line should appear in the slide list where Copilot should add the new slide.
+13. You also notice that there isn't any content in the presentation related to the expected lifespan for each type of heating system. Ask Copilot to research the expected lifespan of boiler heating systems versus furnace heating systems and then add it to a new slide. Before you submit this prompt, select in the slide list where you want the new slide to appear. A red line should appear in the slide list where Copilot should add the new slide. Copilot may ask you to confirm the slide location before it adds the new slide. If it does, select the answer and select **Confirm**.
 
-14. Verify that Copilot added the slide at the selected location. If it didn’t, then drag and drop the slide to the proper location in the list of slides.
+14. Verify that Copilot added the slide at the selected location. If it didn't, then drag and drop the slide to the proper location in the list of slides.
 
-15. You notice that there isn't a slide at the end of the presentation for a Question and Answer (Q&A) session. Ask Copilot to add a Question and Answer (Q&A) slide after the final slide in the presentation.
+15. You notice that there isn't a slide at the end of the presentation for a Question and Answer (Q&A) session. Ask Copilot to add a Question and Answer (Q&A) slide after the final slide in the presentation. If Copilot asks you what type of slide to add, select the answers that you want it to apply, or select **Skip all** if you want Copilot to use its best judgment.
 
-16. Verify that Copilot added the slide at the end of the deck. If it didn’t, then drag and drop the slide to the proper location.
+16. Verify that Copilot added the slide at the end of the deck. If it didn't, then drag and drop the slide to the proper location.

--- a/Instructions/Labs/M07-empower-workforce-copilot-operations/06-Ex1-4-use-chat-prepare-vendor-engagement.md
+++ b/Instructions/Labs/M07-empower-workforce-copilot-operations/06-Ex1-4-use-chat-prepare-vendor-engagement.md
@@ -13,7 +13,7 @@ lab:
 
 # Exercise 1, Task 4: Use Microsoft 365 Copilot Chat to prepare for vendor engagement
 ---
-It’s been quite a day thus far. With Copilot's help, you brainstormed in Whiteboard, researched in Word, and created an executive presentation in PowerPoint. It's late afternoon, but you must still finalize the decision-making process and prepare for vendor engagement before you call it a day. 
+It's been quite a day thus far. With Copilot's help, you brainstormed in Whiteboard, researched in Word, and created an executive presentation in PowerPoint. It's late afternoon, but you must still finalize the decision-making process and prepare for vendor engagement before you call it a day. 
 
 For this final task, you want to consolidate your previous work into actionable outputs:
 
@@ -29,39 +29,39 @@ You plan to use Microsoft 365 Copilot Chat to assist with this process. Chat can
 
 In Copilot Chat on the web, the response mode selector lets you control how much time and reasoning Copilot uses when answering your prompt. You can leave it set to **Auto** (the default option) so Copilot balances speed and depth for you, or choose a faster or more in‑depth response style depending on the task.
 
-When Copilot Chat opens in **Work** mode, the response mode selector isn’t shown. In **Work** mode, Copilot is optimized for secure, work‑context queries, so it automatically manages response depth for you. When you switch to **Web** mode, the response mode selector appears, allowing you to choose between faster responses or deeper reasoning. Once the selector is enabled, it remains visible as you switch between **Work** and **Web** modes.  
+In **Work** mode, Copilot is optimized for secure, work-context queries, while **Web** mode retrieves external information from public sources. In either mode, you can use the response mode selector to choose between faster responses or deeper reasoning, or leave it set to **Auto** to let Copilot decide the appropriate response depth.
 
-If you’ve used Copilot in Excel, you know that it also includes a response control selector. However, its options are different from the Chat selector. In Copilot Chat, the selector controls how deeply Copilot reasons about your request. In Excel, the selector controls which AI model performs the work. Although these selectors might look similar, they control different aspects of Copilot and aren't the same setting.
+If you've used Copilot in Excel, you know that it also includes a response control selector. However, its options are different from the Chat selector. In Copilot Chat, the selector controls how deeply Copilot reasons about your request. In Excel, the selector controls which AI model performs the work. Although these selectors might look similar, they control different aspects of Copilot and aren't the same setting.
 
 Perform the following steps to complete this task:
 
-1.  In your Microsoft Edge browser, go to the **Microsoft 365** home page. Since this task involves reviewing a file uploaded to OneDrive and generating insights from that internal document, select the **Work** option. The **Web** option doesn’t apply here, since it searches external sources like public websites and blogs.
+1. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page. Since this task involves reviewing a file uploaded to OneDrive and generating insights from that internal document, select the **Work** option. The **Web** option doesn't apply here, since it searches external sources like public websites and blogs.
 
-2.  You want to begin by having Copilot help prepare for vendor engagement. Specifically, you want Copilot Chat to summarize the decision criteria that should be used to select an HVAC vendor for this heating system project. You plan to have Copilot use this information to populate a decision matrix. Start by attaching the **Heating System Comparison** report that you created in Task 2 to this prompt.
+2. You want to begin by having Copilot help prepare for vendor engagement. Specifically, you want Copilot Chat to summarize the decision criteria that should be used to select an HVAC vendor for this heating system project. You plan to have Copilot use this information to populate a decision matrix. Start by attaching the **Heating System Comparison** report that you created in Task 2 to this prompt.
 
-3.  Then ask Copilot Chat to summarize the key decision factors from this report. The decision criteria should include cost, energy efficiency, downtime impact, and long-term maintenance considerations.
+3. Then ask Copilot Chat to summarize the key decision factors from this report. The decision criteria should include cost, energy efficiency, downtime impact, and long-term maintenance considerations.
 
-4.  Review the decision criteria and refine it if needed. Review the suggested prompts that Copilot displays and submit any that you feel can help improve the criteria.
+4. Review the decision criteria and refine it if needed. Review the suggested prompts that Copilot displays and submit any that you feel can help improve the criteria.
 
-5.  With the decision criteria now in place, ask Copilot to create a decision matrix that compares three options: boiler repair, boiler replacement, and convert to furnace. Include columns for cost, installation time, energy efficiency, expected lifespan, and risk level. Ask Copilot to use the decision criteria that it previously created to populate the columns in the decision matrix and ensure the comparison aligns with what leadership cares about, which is cost, energy efficiency, downtime, maintenance.
+5. With the decision criteria now in place, ask Copilot to create a decision matrix that compares three options: boiler repair, boiler replacement, and convert to furnace. Include columns for cost, installation time, energy efficiency, expected lifespan, and risk level. Ask Copilot to use the decision criteria that it previously created to populate the columns in the decision matrix and ensure the comparison aligns with what leadership cares about, which is cost, energy efficiency, downtime, and maintenance.
 
-6.  Review the matrix for accuracy and completeness. While it’s a good start, you feel that it’s missing some key information. Ask Copilot to add columns for warranty terms and compliance requirements.
+6. Review the matrix for accuracy and completeness. While it's a good start, you feel that it's missing some key information. Ask Copilot to add columns for warranty terms and compliance requirements.
 
-7.  Review the results. You’re satisfied that all the decision criteria are in place, so now you want to make the decision matrix more actionable. Ask Copilot to rate or score each option against the criteria. Instead of just listing “Risk Level” as a column, Copilot should assign a High, Medium, or Low risk rating for each option. Adding High/Medium/Low ratings makes the matrix actionable for comparing options.
+7. Review the results. You're satisfied that all the decision criteria are in place, so now you want to make the decision matrix more actionable. Ask Copilot to rate or score each option against the criteria. Instead of just listing "Risk Level" as a column, Copilot should assign a High, Medium, or Low risk rating for each option. Adding High/Medium/Low ratings makes the matrix actionable for comparing options.
 
-9.  Review the decision matrix. Examine the suggested prompts that Copilot displays and submit any that you feel can help improve the decision matrix.
+8. Review the decision matrix and refine it further if needed.
 
-8.  Once you finish updating the decision matrix, you can use it as a decision-making tool and a foundation for the RFP and executive summary. Ask Copilot to format the decision matrix as a downloadable Word report that includes a title, introduction, the decision matrix table, and a usage guidance paragraph that explains how to use the matrix for vendor selection. The purpose of the usage guidance paragraph is to help leadership understand how to interpret the matrix.
+9. Once you finish updating the decision matrix, you can use it as a decision-making tool and a foundation for the RFP and executive summary. Ask Copilot to format the decision matrix as a downloadable Word report that includes a title, introduction, the decision matrix table, and a usage guidance paragraph that explains how to use the matrix for vendor selection. The purpose of the usage guidance paragraph is to help leadership understand how to interpret the matrix.
 
 10. Download the decision matrix document once Copilot provides the download link.
 
-11. You’re now ready to have Copilot Chat generate the Request for Proposal (RFP). In the Copilot Chat prompt, attach the decision matrix document that you downloaded and ask Copilot to draft an RFP for HVAC vendors using the decision criteria and the matrix in the attached file. The decision matrix should help Copilot tailor the RFP to the evaluation criteria. The RFP should include project scope, timeline, and evaluation criteria.
+11. You're now ready to have Copilot Chat generate the Request for Proposal (RFP). In the Copilot Chat prompt, attach the decision matrix document that you downloaded and ask Copilot to draft an RFP for HVAC vendors using the decision criteria and the matrix in the attached file. The decision matrix should help Copilot tailor the RFP to the evaluation criteria. The RFP should include project scope, timeline, and evaluation criteria.
 
-12. Review the suggested prompts that Copilot displays and submit any that you feel can help improve the RFP.
+12. Review the RFP for accuracy and completeness, and refine it further if needed.
 
 13. Ask Copilot to format the RFP into a downloadable Word document. Download the RFP once Copilot provides the download link.
 
-14. You’re now at the end of the process. At this point, you want Copilot to create an executive summary that references the decision matrix as the basis for recommendations. Ask Copilot to:
+14. You're now at the end of the process. At this point, you want Copilot to create an executive summary that references the decision matrix as the basis for recommendations. Ask Copilot to:
 
     - Create a one-page executive summary that provides context (a failing boiler and why action is needed)
 
@@ -75,6 +75,6 @@ Perform the following steps to complete this task:
 
     The summary should be decision-ready; in other words, it should give leadership everything they need to quickly understand the situation and make an informed choice without digging through the full report or matrix.
 
-15.  Review the suggested prompts that Copilot displays and submit any that you feel can help improve the executive summary.
+15. Review the suggested prompts that Copilot displays and submit any that you feel can help improve the executive summary. If no suggested prompts are displayed, create and submit your own prompt to improve the executive summary.
 
-16.  Ask Copilot to format the executive summary into a downloadable Word document. Download the document once Copilot provides the download link.
+16. Ask Copilot to format the executive summary into a downloadable Word document. Download the document once Copilot provides the download link.

--- a/Instructions/Labs/M07-empower-workforce-copilot-operations/07-Ex2-introduction-manage-expansion-exercise.md
+++ b/Instructions/Labs/M07-empower-workforce-copilot-operations/07-Ex2-introduction-manage-expansion-exercise.md
@@ -12,7 +12,7 @@ lab:
 
 # Exercise 2: Manage a facility expansion project with Microsoft 365 Copilot
 ---
-In today’s fast-paced business environment, Operations teams are at the heart of organizational success. Whether coordinating complex projects, managing facility upgrades, or ensuring seamless day-to-day processes, Operations professionals must juggle multiple priorities, collaborate across departments, and adapt quickly to changing demands.
+In today's fast-paced business environment, Operations teams are at the heart of organizational success. Whether coordinating complex projects, managing facility upgrades, or ensuring seamless day-to-day processes, Operations professionals must juggle multiple priorities, collaborate across departments, and adapt quickly to changing demands.
 
 Microsoft 365 Copilot is a transformative tool that empowers Operations teams to work smarter, not harder. It harnesses the power of AI to streamline routine tasks, automate communications, and provide actionable insights. In doing so, it frees up time for strategic decision-making and problem-solving.
 
@@ -33,7 +33,7 @@ By integrating Copilot into daily workflows, Operations teams can boost efficien
 
 ### Scenario
 
-As the Operations Lead for Contoso’s regional distribution center in Fargo, North Dakota, you're tasked with managing its upcoming expansion. This initiative is critical to support Contoso’s rapid business growth throughout the Midwest and to improve supply chain efficiency for the upcoming year.
+As the Operations Lead for Contoso's regional distribution center in Fargo, North Dakota, you're tasked with managing its upcoming expansion. This initiative is critical to support Contoso's rapid business growth throughout the Midwest and to improve supply chain efficiency for the upcoming year.
 
 The expansion involves:
 

--- a/Instructions/Labs/M07-empower-workforce-copilot-operations/08-Ex2-1-use-loop-track-milestones.md
+++ b/Instructions/Labs/M07-empower-workforce-copilot-operations/08-Ex2-1-use-loop-track-milestones.md
@@ -9,9 +9,9 @@ lab:
 
 # Exercise 2, Task 1: Use Copilot in Loop to track construction milestones
 ---
-As the Operations Lead for Contoso’s regional distribution center expansion, you’re responsible for keeping the project on schedule and ensuring all teams are aligned. The expansion involves multiple phases—site preparation, construction, inspections, equipment installation, and final handover—each with its own set of dependencies and deadlines.
+As the Operations Lead for Contoso's regional distribution center expansion, you're responsible for keeping the project on schedule and ensuring all teams are aligned. The expansion involves multiple phases—site preparation, construction, inspections, equipment installation, and final handover—each with its own set of dependencies and deadlines.
 
-With so many moving parts and stakeholders (construction crews, logistics, safety, IT, and leadership), it’s critical to have a clear, visual way to track progress and assign responsibilities. Microsoft Loop, enhanced by Copilot, is your central hub for organizing and monitoring every milestone. Within your Loop workspace for your project plan, you plan to create the following pages:
+With so many moving parts and stakeholders (construction crews, logistics, safety, IT, and leadership), it's critical to have a clear, visual way to track progress and assign responsibilities. Microsoft Loop, enhanced by Copilot, is your central hub for organizing and monitoring every milestone. Within your Loop workspace for your project plan, you plan to create the following pages:
 
 - 1-Milestones and Timeline
 - 2-RAID Log (Risks, Assumptions, Issues, Dependencies)
@@ -22,46 +22,50 @@ A typical construction project of this nature would have many other tasks that y
 
 Perform the following steps to complete this task:
 
-1.  In your Microsoft Edge browser, sign in to the **Microsoft 365** home page **(https://www.microsoft365.com)**, select **Apps** in the navigation pane, and then select **Loop** from the **Apps** menu.
-
-2.  In **Loop for the web,** create a new workspace titled **Distribution Center Expansion – Project Plan**.
-
-3.  You plan to create three new pages under this Loop workspace – one for negotiation strategy, another for risk mitigation ideas, and a third for communication framing. Change the current title of the first page from **Untitled** to **1-Milestones and Timeline**.
-
-4.  Open the Copilot pane. Ask Copilot to generate a table of key milestones and associated timelines for the distribution center expansion by submitting the following prompt:
+1. In your Microsoft Edge browser, sign in to the **Microsoft 365 Copilot** home page [**https://m365.cloud.microsoft.com**](https://m365.cloud.microsoft.com), select **Apps** in the navigation pane, and then select **Loop** from the **Apps** menu.
 
    > [!NOTE]
-   > For this first prompt, we’ve provided the text so you can see what an effective prompt looks like when it incorporates the four key elements discussed in the Introduction unit. You must write all remaining prompts in this exercise, but in doing so, you can use this prompt as a model to emulate.
+   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Loop** from the list of apps that appears.
+
+
+2. In **Loop for the web**, select the plus sign **(+)** icon, then select **New workspace** to create a new workspace titled **Distribution Center Expansion – Project Plan**. Select the **Create** button.
+
+3. You plan to create three new pages under this Loop workspace – one for negotiation strategy, another for risk mitigation ideas, and a third for communication framing. Change the current title of the first page from **Untitled** to **1-Milestones and Timeline**.
+
+4. Open the Copilot pane. Ask Copilot to generate a table of key milestones and associated timelines for the distribution center expansion by submitting the following prompt:
+
+   > [!NOTE]
+   > For this first prompt, we've provided the text so you can see what an effective prompt looks like when it incorporates the four key elements discussed in the Introduction unit. You must write all remaining prompts in this exercise, but in doing so, you can use this prompt as a model to emulate.
     
-   **I’m the Operations Lead overseeing Contoso’s distribution center expansion project in Fargo, ND. This project involves multiple construction phases, safety updates, vendor coordination, and inventory transitions. Please build a detailed project plan that outlines all major milestones for this expansion. Organize the plan into a table with columns for: Task Name, Bucket/Phase, Start Date, Due Date, Dependencies, Owner (role), and Checklist Items. Use logical buckets such as Site Prep, Construction, Facility Systems, Inspections, and Go-Live Readiness. Assume the project begins next Monday and spans 24 weeks. Return the plan as a Loop table I can edit.**
+   **I'm the Operations Lead overseeing Contoso's distribution center expansion project in Fargo, ND. This project involves multiple construction phases, safety updates, vendor coordination, and inventory transitions. Please build a detailed project plan that outlines all major milestones for this expansion. Organize the plan into a table with columns for: Task Name, Bucket/Phase, Start Date, Due Date, Dependencies, Owner (role), and Checklist Items. Use logical buckets such as Site Prep, Construction, Facility Systems, Inspections, and Go-Live Readiness. Assume the project begins next Monday and spans 24 weeks. Return the plan as a Loop table I can edit.**
 
-5.  Review the table results. Loop might ask if you want it to insert the table directly into your Loop page. During testing, Copilot didn’t display either a button or a suggested prompt directing it to insert the table into the Loop page. When we entered a prompt asking it to do that, it regenerated the same table, but it didn’t insert it. Since Copilot in Loop is still a work in progress, the easiest way to insert the table into the Loop page is to select the **Copy** icon that appears below the table. Paste the copied results into your **1-Milestones and Timeline** page. Delete any extraneous text from the conversation in the Copilot pane that was copied and pasted along with the table (typically at the beginning and end of the pasted content).
+5. Review the table results. Loop might ask if you want it to insert the table directly into your Loop page. During testing, Copilot didn't display either a button or a suggested prompt directing it to insert the table into the Loop page. When we entered a prompt asking it to do that, it regenerated the same table, but it didn't insert it. Since Copilot in Loop is still a work in progress, the easiest way to insert the table into the Loop page is to select the **Copy** icon that appears below the table. Paste the copied results into your **1-Milestones and Timeline** page. Delete any extraneous text from the conversation in the Copilot pane that was copied and pasted along with the table (typically at the beginning and end of the pasted content).
 
-6.  Scroll horizontally to view all the table columns. In a real-world situation, the Operation Lead would exercise operational reasoning by editing the dates and owner roles, add/remove checklist items, and reorder tasks as needed. For this exercise, you can leave the table results as is.
+6. Scroll horizontally to view all the table columns. In a real-world situation, the Operations Lead would exercise operational reasoning by editing the dates and owner roles, adding or removing checklist items, and reordering tasks as needed. For this exercise, you can leave the table results as is.
 
-7.  Next, add a new page under your **Distribution Center Expansion – Project Plan** workspace. Change the title of the page from **Untitled** to **2-RAID Log (Risk/Assumption/Issue/Dependency)**.
+7. Next, add a new page under your **Distribution Center Expansion – Project Plan** workspace. Change the title of the page from **Untitled** to **2-RAID Log (Risk/Assumption/Issue/Dependency)**.
 
-8.  Open the Copilot pane. To facilitate coordination between construction, safety, inventory moves, and vendors with tight dates, ask Copilot to create a RAID log table capturing top items for the next 24 weeks, including impact/probability scoring and mitigation owners aligned to Operations roles. This Loop table should include the following columns: Type, Title, Description, Impact (High/Medium/Low), Probability (High/Medium/Low), Owner (role), Target Date, Mitigation/Action, and Status. Define critical path risks in a short paragraph below the table.
+8. Open the Copilot pane. To facilitate coordination between construction, safety, inventory moves, and vendors with tight dates, ask Copilot to create a RAID log table capturing top items for the next 24 weeks, including impact/probability scoring and mitigation owners aligned to Operations roles. This Loop table should include the following columns: Type, Title, Description, Impact (High/Medium/Low), Probability (High/Medium/Low), Owner (role), Target Date, Mitigation/Action, and Status. Define critical path risks in a short paragraph below the table.
 
-9.  Review the table results and the paragraph that identifies critical path risks that Copilot generated. If everything looks fine, copy and paste the content into the **2-RAID Log** page and delete an extraneous text.
+9. Review the table results and the paragraph that identifies critical path risks that Copilot generated. If everything looks fine, copy and paste the content into the **2-RAID Log** page and delete any extraneous text.
 
-10.  Next, add a third page under your **Distribution Center Expansion – Project Plan** workspace. Change the title of the page from **Untitled** to **3-RACI Matrix (Roles and Responsibilities)**.
+10. Next, add a third page under your **Distribution Center Expansion – Project Plan** workspace. Change the title of the page from **Untitled** to **3-RACI Matrix (Roles and Responsibilities)**.
 
-11.  Open the Copilot pane. To help the Operations team assign task owners and clarify communication flows, ask Copilot to build a RACI matrix for the following milestones: site prep, foundation, framing, electrical, sprinkler testing, dock upgrades, inspection, equipment install, and go-live readiness. To do so, create a Loop table with rows = milestones and columns = roles (Operations Lead, Construction Lead, Safety Manager, Logistics Coordinator, Finance, IT, Vendor PM) and values = R/A/C/I.
+11. Open the Copilot pane. To help the Operations team assign task owners and clarify communication flows, ask Copilot to build a RACI matrix for the following milestones: site prep, foundation, framing, electrical, sprinkler testing, dock upgrades, inspection, equipment install, and go-live readiness. To do so, create a Loop table with rows = milestones and columns = roles (Operations Lead, Construction Lead, Safety Manager, Logistics Coordinator, Finance, IT, Vendor PM) and values = R/A/C/I.
 
-12.  Review the table results. If everything looks fine, copy and paste the table into the **3-RACI Matrix** page and delete an extraneous text.
+12. Review the table results. If everything looks fine, copy and paste the table into the **3-RACI Matrix** page and delete any extraneous text.
 
-13.  Add a final page under your **Distribution Center Expansion – Project Plan** workspace. Change the title of the page from **Untitled** to **4-Decision Log and Change Log**.
+13. Add a final page under your **Distribution Center Expansion – Project Plan** workspace. Change the title of the page from **Untitled** to **4-Decision Log and Change Log**.
 
-14.  Open the Copilot pane. This page includes two tables – a Decision Log and a Change Log. Rather than have Copilot generate both tables at one time, you plan to submit each prompt request separately. To help the Operation Leader track upcoming approvals for weekend shifts, vendor hours, and PPE budget, ask Copilot to create a Decision Log table that includes the following columns: Decision, Requested By, Due Date, Options Considered, Final Decision, Rationale, Owner, and Follow-up Tasks.
+14. Open the Copilot pane. This page includes two tables – a Decision Log and a Change Log. Rather than have Copilot generate both tables at one time, you plan to submit each prompt request separately. To help the Operations Lead track upcoming approvals for weekend shifts, vendor hours, and PPE budget, ask Copilot to create a Decision Log table that includes the following columns: Decision, Requested By, Due Date, Options Considered, Final Decision, Rationale, Owner, and Follow-up Tasks.
 
-15.  Review the table results. If everything looks fine, copy and paste the Decision Log table into the **4-Decision Log and Change Log** page and delete an extraneous text.
+15. Review the table results. If everything looks fine, copy and paste the Decision Log table into the **4-Decision Log and Change Log** page and delete any extraneous text.
 
-16.  Next, ask Copilot to create a Change Log table for tracking potential shifts in inspection dates, routing, and go-live readiness. The table should include the following columns: Change Request, Category (Schedule/Scope/Cost/Quality), Description, Impact Summary, Approval Needed, Status, Owner, Effective Date.
+16. Next, ask Copilot to create a Change Log table for tracking potential shifts in inspection dates, routing, and go-live readiness. The table should include the following columns: Change Request, Category (Schedule/Scope/Cost/Quality), Description, Impact Summary, Approval Needed, Status, Owner, Effective Date.
 
-17.  Review the table results. If everything looks fine, copy and paste the Change Log table into the **4-Decision Log and Change Log** page and delete an extraneous text.
+17. Review the table results. If everything looks fine, copy and paste the Change Log table into the **4-Decision Log and Change Log** page and delete any extraneous text.
 
-18.  In a later task, you create an email for your Operations colleagues that includes a link to the Loop workspace that you created in this task. Keep the **Distribution Center Expansion – Project Plan** workspace open so that you can copy its link.
+18. In a later task, you create an email for your Operations colleagues that includes a link to the Loop workspace that you created in this task. Keep the **Distribution Center Expansion – Project Plan** workspace open so that you can copy its link.
 
 
 

--- a/Instructions/Labs/M07-empower-workforce-copilot-operations/08-Ex2-1-use-loop-track-milestones.md
+++ b/Instructions/Labs/M07-empower-workforce-copilot-operations/08-Ex2-1-use-loop-track-milestones.md
@@ -22,11 +22,7 @@ A typical construction project of this nature would have many other tasks that y
 
 Perform the following steps to complete this task:
 
-1. In your Microsoft Edge browser, sign in to the **Microsoft 365 Copilot** home page [**https://m365.cloud.microsoft.com**](https://m365.cloud.microsoft.com), select **Apps** in the navigation pane, and then select **Loop** from the **Apps** menu.
-
-   > [!NOTE]
-   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Loop** from the list of apps that appears.
-
+1. In your Microsoft Edge browser, sign in to the **Microsoft 365 Copilot** home page [**https://m365.cloud.microsoft.com**](https://m365.cloud.microsoft.com), select the **App Launcher** (grid icon), and then select **More Apps**. From the list of apps, select **Loop**.
 
 2. In **Loop for the web**, select the plus sign **(+)** icon, then select **New workspace** to create a new workspace titled **Distribution Center Expansion – Project Plan**. Select the **Create** button.
 

--- a/Instructions/Labs/M07-empower-workforce-copilot-operations/09-Ex2-2-create-facility-expansion-agent.md
+++ b/Instructions/Labs/M07-empower-workforce-copilot-operations/09-Ex2-2-create-facility-expansion-agent.md
@@ -1,7 +1,7 @@
 ---
 lab:
   title: 'Exercise 2, Task 2: Use Copilot Studio to build a Facility Expansion FAQ agent'
-  description: '<br/For this agent, enter the following prompt and then select the forward arrow (Send) icon to submit the prompt: <br/Create an agent titled Facility Expansion FAQ Assistant. The purpose of this agent is to answer employee questions about Contoso’s Fargo distribution center expansion, such as construction timelines, safety protocols, temporary evacuation routes, inventory move waves, vendor access requirements, and operational impacts—using only approved documents that are assigned to this agent as knowledge sources.'
+  description: 'For this agent, enter the following prompt and then select the forward arrow (Send) icon to submit the prompt: Create an agent titled Facility Expansion FAQ Assistant. The purpose of this agent is to answer employee questions about Contoso’s Fargo distribution center expansion, such as construction timelines, safety protocols, temporary evacuation routes, inventory move waves, vendor access requirements, and operational impacts—using only approved documents that are assigned to this agent as knowledge sources.'
   duration: 48 minutes
   level: 100
   islab: true
@@ -9,24 +9,24 @@ lab:
 
 # Exercise 2, Task 2: Use Copilot Studio to build a Facility Expansion FAQ agent
 ---
-Contoso broke ground on the Fargo distribution center expansion. The company is tracking project milestones in Loop (Task 1). As the Operations Leader, you received feedback that leadership and frontline teams need reliable, one‑stop answers to recurring questions about construction timelines, temporary access changes, safety requirements, and inventory move windows—without flooding Operations with emails or chat pings.
+Contoso broke ground on the Fargo distribution center expansion. The company is tracking project milestones in Loop (Task 1). As the Operations Leader, you received feedback that leadership and frontline teams need reliable, one-stop answers to recurring questions about construction timelines, temporary access changes, safety requirements, and inventory move windows—without flooding Operations with emails or chat pings.
 
 Questions are coming in from across the organization:
 
-- Frontline staff (warehouse/floor teams) seeking day‑to‑day guidance.
+- Frontline staff (warehouse/floor teams) seeking day-to-day guidance.
 - Supervisors and Coordinators (safety, logistics) who need quick references.
 - Leadership and project program managers who want authoritative answers to status/impact questions.
 
 Many of the questions that Operations staff ask are similar every day. For example:
 
-- “Is Dock 3 open yet?”
-- “Which temporary evacuation routes apply to Packing?”
-- “When do CHAI‑12 and COFF‑08 move?”
-- “What PPE is required in the new wing?”
+- "Is Dock 3 open yet?"
+- "Which temporary evacuation routes apply to Packing?"
+- "When do CHAI-12 and COFF-08 move?"
+- "What PPE is required in the new wing?"
 
-The scope of questions is beginning to overwhelm the Operations team, especially given the fact that answers must be consistent, citation‑based, and available 24/7. To address this issue, you decide to take advantage of Microsoft 365 Copilot’s AI assistant functionality and create a Q&A agent that can:
+The scope of questions is beginning to overwhelm the Operations team, especially given the fact that answers must be consistent, citation‑based, and available 24/7. To address this issue, you decide to take advantage of Microsoft 365 Copilot's AI assistant functionality and create a Q&A agent that can:
 
-- Answer natural‑language questions about the expansion using connected, approved documents.
+- Answer natural-language questions about the expansion using connected, approved documents.
 
 - Show citations/links so users can trust and verify details.
 
@@ -39,7 +39,7 @@ The scope of questions is beginning to overwhelm the Operations team, especially
 
 Perform the following steps to complete this task:
 
-1.  Select each of the following links to download their respective files and store them in your OneDrive account:
+1. Select each of the following links to download their respective files and store them in your OneDrive account:
 
     - [**Contoso_Expansion_Project_Overview.docx**](https://go.microsoft.com/fwlink/?linkid=2347809)
 
@@ -55,89 +55,97 @@ Perform the following steps to complete this task:
 
     - [**Contoso_Vendor_Access_and_Hours.docx**](https://go.microsoft.com/fwlink/?linkid=2347521)
 
-2.  Open a new tab in your Microsoft Edge browser and then open Microsoft 365.
+2. Open a new tab in your Microsoft Edge browser and then open **Microsoft 365 Copilot**.
 
-3.  In Microsoft 365, select **New agent** in the navigation pane. Doing so opens Copilot Studio’s **Agent Builder** and displays the **New agent** page.
+3. In Microsoft 365 Copilot, select **Agents** in the navigation pane, then select **Create agent**. Doing so opens Copilot Studio's **Agent Builder** and displays the **New agent** page.
 
-4.  On the **New Agent** page, you want to ask Copilot to create an agent. In the prompt, you should enter the agent’s name and a general description of what the agent is about, who its target audience is, and what you want it to do.  
-    <br/>For this agent, enter the following prompt and then select the forward arrow (Send) icon to submit the prompt:  
-    <br/>**Create an agent titled Facility Expansion FAQ Assistant. The purpose of this agent is to answer employee questions about Contoso’s Fargo distribution center expansion, such as construction timelines, safety protocols, temporary evacuation routes, inventory move waves, vendor access requirements, and operational impacts—using only approved documents that are assigned to this agent as knowledge sources.**
+4. On the **New Agent** page, you want to ask Copilot to create an agent. In the prompt, you should enter the agent's name and a general description of what the agent is about, who its target audience is, and what you want it to do.  
+    
+    For this agent, enter the following prompt and then select the forward arrow (Send) icon to submit the prompt:  
+    
+    **Create an agent titled Facility Expansion FAQ Assistant. The purpose of this agent is to answer employee questions about Contoso's Fargo distribution center expansion, such as construction timelines, safety protocols, temporary evacuation routes, inventory move waves, vendor access requirements, and operational impacts-using only approved documents that are assigned to this agent as knowledge sources.**
 
-5.  After you selected the forward arrow, the **Agent Builder** form appeared for your new agent. At the top of the form is a **Describe** tab and a **Configure** tab.
+5.  After you submit the prompt, the **Agent Builder** form appears for your new agent. The **Agent Builder** chat pane appears on the left, and the agent details appear on the right. At the top of the form are a **Configure** tab and a **Preview** tab.
 
-    - The **Describe** tab enables you to carry on a conversation with Copilot. This tab is displayed by default.
+    - The **Agent Builder** chat pane on the left enables you to carry on a conversation with Copilot to refine your agent.
 
-    - The **Configure** tab enables you to define the detailed settings that drive the agent.
+    - The **Preview** tab enables you to test the agent by entering starter prompts or custom messages.
 
-    Wait a minute or two for Copilot to create the agent, at which time it displays the agent’s name and description in the **Agent preview** pane.
+    Wait a minute or two for Copilot to create the agent, at which time it displays the agent's name and description in the **Agent preview** pane.
 
-6.  Select the **Configure** tab at the top of the form. Let’s see what Copilot did based on the prompt that you entered.
+6. Select the **Configure** tab at the top of the form. Let's see what Copilot did based on the prompt that you entered.
 
-7.  On the **Configure** tab, the **Name** and **Description** fields should be filled in based on the prompt that you entered. Scroll down to the **Instructions** field. Copilot generated these instructions based on the description that you provided in your initial prompt. Review the detailed level of instructions that Copilot generated.
+7. On the **Configure** tab, the **Name** and **Description** fields should be filled in based on the prompt that you entered. Scroll down to the **Instructions** field. Copilot generated these instructions based on the description that you provided in your initial prompt. Review the detailed level of instructions that Copilot generated.
 
    > [!IMPORTANT]
    > The beauty of the Agent Builder process is that Copilot automatically translates your basic, natural language description into a complex set of instructions. This process saves you from creating this detailed instruction set on your own.
 
-8.  If you wish to change the instructions, you can either manually edit them directly in the **Instructions** field, or you can ask Copilot to update the instructions for you.  
-    <br/>After reviewing the **Instructions**, you decide that you want to have Copilot add a couple of other items to the instruction set. To do so, select the **Describe** tab and then enter the following prompt:
+8. If you wish to change the instructions, you can either manually edit them directly in the **Instructions** field, or you can ask Copilot to update the instructions for you.  
+    
+    After reviewing the **Instructions**, you decide that you want to have Copilot add a couple of other items to the instruction set. To do so, select the **Agent Builder** chat pane on the left and then enter the following prompt:
 
     **Update the Instructions to include the following items:**
 
-    - **Don’t speculate. If information is missing or ambiguous, flag the gap and provide a polite fallback response, such as: “I don’t have a verified answer for that yet. Please check the Expansion Overview or contact Operations Intake.”**
+    - **Don't speculate. If information is missing or ambiguous, flag the gap and provide a polite fallback response, such as: "I don't have a verified answer for that yet. Please check the Expansion Overview or contact Operations Intake."**
 
-    - **Politely decline sensitive topics (for example, budget breakdowns or contracts) with: “I’m unable to share that information. Please contact the Project Controller.”**
+    - **Politely decline sensitive topics (for example, budget breakdowns or contracts) with: "I'm unable to share that information. Please contact the Project Controller."**
 
-    - **Keep answers specific to the Fargo expansion and the current 24‑week timeline.**
+    - **Keep answers specific to the Fargo expansion and the current 24-week timeline.**
 
     - **Provide links/citations and highlight critical dates or zones in the response.**
 
-9.  Review Copilot’s response after updating the instructions. To verify the changes that Copilot made, select the **Configure** tab and then scroll down to the **Instructions** field. Verify that Copilot added the new instructions that you requested.
+9. Review Copilot's response after updating the instructions. To verify the changes that Copilot made, select the **Configure** tab and then scroll down to the **Instructions** field. Verify that Copilot added the new instructions that you requested.
 
-10.  While the current instructions look good, you wonder if they could be improved upon. You aren't sure how to improve them, so you decide to ask Copilot what it thinks.  
-    <br/>To do so, select the **Describe** tab. This time, enter a prompt that asks Copilot what other instructions it would recommend that could improve this agent.
+10. While the current instructions look good, you wonder if they could be improved upon. You aren't sure how to improve them, so you decide to ask Copilot what it thinks.  
+    
+    To do so, select the **Agent Builder** chat pane on the left. This time, enter a prompt that asks Copilot what other instructions it would recommend that could improve this agent.
 
-11.  Review Copilot’s recommendations. You’re pleased with its suggestions, so ask Copilot to add them all to the agent’s instructions.
+11. Review Copilot's recommendations. You're pleased with its suggestions, so ask Copilot to add them all to the agent's instructions.
 
-12.  Once Copilot responds that it updated the instructions, select the **Configure** tab and scroll through the **Instructions**. Note the new items that Copilot added.
+12. Once Copilot responds that it updated the instructions, select the **Configure** tab and scroll through the **Instructions**. Note the new items that Copilot added.
 
-13.  Now that you’re satisfied with the instructions, you’re ready to configure the agent’s knowledge sources and starter prompts.  
-    <br/>In the **Configure** tab, scroll down to the **Knowledge** section and verify the **Search all websites** toggle switch is disabled. Copilot should have disabled this toggle switch when it created the agent based on the description you provided in your original prompt, which told it to only use the files that you provide. If the toggle switch is enabled, then disable it now.
+13. Now that you're satisfied with the instructions, you're ready to configure the agent's knowledge sources and starter prompts.  
+    
+    In the **Configure** tab, scroll down to the **Knowledge** section and verify the **Web search** toggle switch is disabled. Copilot should have disabled this toggle switch when it created the agent based on the description you provided in your original prompt, which told it to use only the files that you provide. If the toggle switch is enabled, then disable it now.
 
-14.  In the **Knowledge** section, select the **Upload from device** icon that appears next to the **Enter a URL or name or drop files here** field. In the **File Explorer** window that appears, navigate to your **OneDrive** folder and select the seven files that you downloaded in step 1 and stored on your OneDrive.
+14. In the **Knowledge** section, select the **+ Add knowledge** button. In the data picker that appears, use the search field (**Paste a link or search for your data**) or the **Files** tab to locate and select the seven files that you downloaded in step 1 and stored on your OneDrive.
 
-15.  For **Suggested prompts**, you can have Copilot generate prompts for you, or you can manually create your own prompts. Let’s try both methods.  
-    <br/>To have Copilot generate suggested prompts, select the **Describe** tab and then ask Copilot to generate three suggested prompts for the agent. Note how each prompt has a title and a message.
+15. For **Suggested prompts**, you can have Copilot generate prompts for you, or you can manually create your own prompts. Let's try both methods.  
+    
+    To have Copilot generate suggested prompts, select the **Agent Builder** chat pane on the left and then ask Copilot to generate three suggested prompts for the agent. Note how each prompt has a title and a message.
 
-16.  You now want to enter several of your own prompts. Select the **Configure** tab and scroll down to the **Suggested prompts** section. You should see the three prompts that Copilot added to the agent.  
-    <br/>For each prompt that you want to manually add, select the **Add a suggested prompt** option that appears below the prompts.  
-    <br/>Six suggested prompts are displayed below that are related to popular facility expansion topics. Review these prompts, select two or three that you like, and then add them to the agent.
+16. You now want to enter several of your own prompts. Select the **Configure** tab and scroll down to the **Suggested prompts** section. You should see the three prompts that Copilot added to the agent.  
+    
+    For each prompt that you want to manually add, select the **+ Add a suggested prompt** option that appears below the prompts.  
+    
+    Six suggested prompts related to popular facility expansion topics are displayed below. Review these prompts, select two or three that you like, and then add them to the agent.
 
-        - **Title:** Construction Timeline Check
-            - **Message:** What construction phase are we currently in for the Fargo distribution center expansion, and which areas of the building are affected this week?  
+    - **Title:** Construction Timeline Check
+        - **Message:** What construction phase are we currently in for the Fargo distribution center expansion, and which areas of the building are affected this week?  
                 
-        - **Title:** PPE & Safety Requirements
-            - **Message:** What PPE is required in the construction-adjacent zones, and do these requirements change during the 24‑week expansion?  
+    - **Title:** PPE & Safety Requirements
+        - **Message:** What PPE is required in the construction-adjacent zones, and do these requirements change during the 24-week expansion?  
                 
-        - **Title:** Temporary Evacuation Route Guidance
-            - **Message:** What is the temporary evacuation route for the Packing area during the expansion, and where is the nearest assembly point?  
+    - **Title:** Temporary Evacuation Route Guidance
+        - **Message:** What is the temporary evacuation route for the Packing area during the expansion, and where is the nearest assembly point?  
                 
-        - **Title:** Inventory Move Wave Details
-            - **Message:** Which SKUs are included in the next inventory move wave, and what are the start and end dates for that wave?  
+    - **Title:** Inventory Move Wave Details
+        - **Message:** Which SKUs are included in the next inventory move wave, and what are the start and end dates for that wave?  
                 
-        - **Title:** Vendor Access & Parking Instructions
-            - **Message:** Where should vendors park during the expansion, and what are the temporary access hours and check‑in rules?  
+    - **Title:** Vendor Access & Parking Instructions
+        - **Message:** Where should vendors park during the expansion, and what are the temporary access hours and check-in rules?  
                 
-        - **Title:** Operational Impacts Summary
-            - **Message:** What operational impacts should staff expect over the next few weeks due to the ongoing construction and dock upgrades?  
+    - **Title:** Operational Impacts Summary
+        - **Message:** What operational impacts should staff expect over the next few weeks due to the ongoing construction and dock upgrades?  
                 
-17.  Test several of the suggested prompts. Verify the agent is correctly pulling in data from the knowledge source documents. You submit custom prompts in the next task.
+17. Test several of the suggested prompts by selecting the **Preview** tab. Verify the agent is correctly pulling in data from the knowledge source documents. You submit custom prompts in the next task.
 
-18. Once you’re satisfied with the results for the suggested prompts, select the **Create** button to create the agent.
+18. Once you're satisfied with the results for the suggested prompts, select the **Create** button to create the agent.
 
 19. Once the agent is created, a dialog box appears that indicates the agent was successfully created. In this dialog box, you can either go to the agent or share it. Select the **Go to agent** option.
 
 > [!NOTE]
-> At this stage, the agent is private and accessible only to you. In a real-world scenario where the agent needs to be used by multiple team members, you would share it with those individuals. For this training exercise, sharing isn’t required since you’re working within your own tenant.
+> At this stage, the agent is private and accessible only to you. In a real-world scenario where the agent needs to be used by multiple team members, you would share it with those individuals. For this training exercise, sharing isn't required because you're working within your own tenant.
 
 
 

--- a/Instructions/Labs/M07-empower-workforce-copilot-operations/10-Ex2-3-use-facility-expansion-agent.md
+++ b/Instructions/Labs/M07-empower-workforce-copilot-operations/10-Ex2-3-use-facility-expansion-agent.md
@@ -9,39 +9,39 @@ lab:
 
 # Exercise 2, Task 3: Ask the Facility Expansion FAQ agent questions about the expansion project
 ---
-In this task, you take on the role of Contoso project manager who’s involved in the expansion project at the Fargo distribution center. Each day, you find yourself wondering about different aspects of project. Rather than inundating the Operations team with your questions, you decide to take advantage of the Facility Expansion FAQ Assistant to answer your questions.
+In this task, you take on the role of Contoso project manager who's involved in the expansion project at the Fargo distribution center. Each day, you find yourself wondering about different aspects of the project. Rather than inundating the Operations team with your questions, you decide to take advantage of the Facility Expansion FAQ Assistant to answer your questions.
 
 Perform the following steps to complete this task:
 
-1.  The **Facility Expansion FAQ Assistant** should still be open from the prior task. If not, then select the agent on the Microsoft 365 home page.
+1. The **Facility Expansion FAQ Assistant** should still be open from the prior task. If not, then select the agent on the Microsoft 365 home page.
 
-2.  Start a conversation with your **Facility Expansion FAQ Assistant**. Ask questions about the following topics related to the distribution center expansion:
+2. Start a conversation with your **Facility Expansion FAQ Assistant**. Ask questions about the following topics related to the distribution center expansion:
 
-    - What’s the temporary evacuation route from Packing?
+    - What's the temporary evacuation route from Packing?
 
     - Are forklifts allowed in the new wing this week?
 
-    - When do SKU CHAI‑12 and COFF‑08 move to the new racks?
+    - When do SKU CHAI-12 and COFF-08 move to the new racks?
 
-3.  Observe how the agent’s responses cite or summarize information from the policy files. Observe how the agent’s responses cite or summarize information from the policy files. Evaluate the completeness and clarity of the agent’s answers. Note any policies that might need to be updated for better self-service accuracy.
+3. Observe how the agent's responses cite or summarize information from the policy files. Evaluate the completeness and clarity of the agent's answers. Note any policies that might need to be updated for better self-service accuracy.
 
-4.  Now ask some questions that aren’t covered by the knowledge source documents, such as:
+4. Now ask some questions that aren't covered by the knowledge source documents, such as:
 
     - What is the total cost of the Fargo expansion project, and which contractor submitted the lowest bid?
-        - **Expected outcome:** None of the knowledge sources contain any financials, bids, cost breakdowns, or vendor contract terms. The agent should decline politely and provide fallback, such as “contact the Project Controller.”
+        - **Expected outcome:** None of the knowledge sources contain any financials, bids, cost breakdowns, or vendor contract terms. The agent should decline politely and provide fallback, such as "contact the Project Controller."
 
     - Will the new wing include an automated picking system or robotics platform?
-        - **Expected outcome:** The overview mentions systems in general (electrical, HVAC, lighting), but not specific technology purchases. The agent should indicate that the information isn’t available.
+        - **Expected outcome:** The overview mentions systems in general (electrical, HVAC, lighting), but not specific technology purchases. The agent should indicate that the information isn't available.
 
-5.  Evaluate how the agent responded to questions that aren’t covered in the knowledge source files. Did the agent provide an appropriate fallback response?
+5. Evaluate how the agent responded to questions that aren't covered in the knowledge source files. Did the agent provide an appropriate fallback response?
 
-6.  Now ask some questions that are partially covered by the knowledge source documents, such as:
+6. Now ask some questions that are partially covered by the knowledge source documents, such as:
 
     - When will the facility return to normal routing, and what permanent safety procedures will replace the temporary ones?
-        - **Expected outcome:** The agent can provide partial information, since the knowledge sources provide timelines, temporary routing, and temporary PPE. However, the knowledge sources don’t provide information on permanent future procedures or post-project traffic designs. The agent should answer what is known and flag what’s missing.
+        - **Expected outcome:** The agent can provide partial information, since the knowledge sources provide timelines, temporary routing, and temporary PPE. However, the knowledge sources don't provide information on permanent future procedures or post-project traffic designs. The agent should answer what is known and flag what's missing.
 
-    - Exactly how many pallets do we plan to move during Wave 5, and what’s the breakdown by product category?
-        - **Expected outcome:** The agent can provide partial information, since the knowledge sources provide estimated quantities and SKU groups. However, the knowledge sources don’t provide information on full SKU lists, product categories, and pallet-level detail. The agent should answer what is known and flag what’s missing.  
-            
-7.  Evaluate how the agent responded to questions that are partially covered in the knowledge source files. Did the agent provide an appropriate fallback response for the portions of the questions that weren’t covered in the knowledge source documents?
+    - Exactly how many pallets do we plan to move during Wave 5, and what's the breakdown by product category?
+        - **Expected outcome:** The agent can provide partial information, since the knowledge sources provide estimated quantities and SKU groups. However, the knowledge sources don't provide information on full SKU lists, product categories, and pallet-level detail. The agent should answer what is known and flag what's missing.
+
+7. Evaluate how the agent responded to questions that are partially covered in the knowledge source files. Did the agent provide an appropriate fallback response for the portions of the questions that weren't covered in the knowledge source documents?
 

--- a/Instructions/Labs/M07-empower-workforce-copilot-operations/11-Ex2-4-use-onenote-update-safety-protocols.md
+++ b/Instructions/Labs/M07-empower-workforce-copilot-operations/11-Ex2-4-use-onenote-update-safety-protocols.md
@@ -9,40 +9,43 @@ lab:
 
 # Exercise 2, Task 4: Use Copilot in OneNote to update safety protocols
 ---
-As the Operations Lead for Contoso’s regional distribution center expansion, you just discovered that several areas of the existing safety protocol manual are outdated. Temporary construction zones, new equipment installations, altered traffic flows, and updated emergency exits all introduce new risks and procedures that Operations staff must understand.
+As the Operations Lead for Contoso's regional distribution center expansion, you just discovered that several areas of the existing safety protocol manual are outdated. Temporary construction zones, new equipment installations, altered traffic flows, and updated emergency exits all introduce new risks and procedures that Operations staff must understand.
 
-You're tasked with revising the regional distribution center’s safety protocols using Copilot in OneNote. Your goal is to review existing procedures, update sections impacted by the expansion, and generate a summary of changes that can be shared with the Operations team.
+You're tasked with revising the regional distribution center's safety protocols using Copilot in OneNote. Your goal is to review existing procedures, update sections impacted by the expansion, and generate a summary of changes that can be shared with the Operations team.
 
 Perform the following steps to complete this task:
 
-1.  Select the following link to download the [**Contoso Expansion Safety Procedures.onepkg**](https://go.microsoft.com/fwlink/?linkid=2347515) file. Store the file in your OneDrive account for use by Copilot in your tenant.
+1. Select the following link to download the [**Contoso Expansion Safety Procedures.onepkg**](https://go.microsoft.com/fwlink/?linkid=2347515) file. Store the file in your OneDrive account for use by Copilot in your tenant.
 
-2.  In your Microsoft Edge browser, go to the **Microsoft 365** home page, select **Apps** in the navigation pane, and then on the **Apps** page, select **OneNote**.
+2. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page, select **Apps** in the navigation pane, and then on the **Apps** page, select **OneNote**.
 
-3.  In **OneNote for the web**, in the list of OneNote files, the **All** tab should display the **Contoso Expansion Safety Procedures** file. If the file doesn’t appear in the list, enter **Contoso** in the Search box. The **Contoso Expansion Safety Procedures** file should appear in the list of files. Select the file to open it.
+   > [!NOTE]
+   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **OneNote** from the list of apps that appears.
 
-4.  Select **Copilot** in the menu bar to open the Copilot pane. If announcements appear, select the **Skip** button at the bottom of the Copilot pane to close them.
+3. In **OneNote for the web**, in the list of OneNote files, the **Recent** list should display the **Safety Procedures** file. If the file doesn't appear in the list, enter `Contoso` in the **Search** box. The **Safety Procedures** file should appear in the list of files. Select the file to open it.
 
-5.  Ask Copilot to review these safety procedures and identify any areas that might be affected by the construction of the new warehouse wing and dock upgrades.
+4. Select **Copilot** in the menu bar to open the Copilot pane. If announcements appear, select the **Skip** button at the bottom of the Copilot pane to close them.
 
-6.  Review Copilot’s analysis and note the impacted areas. At the end of Copilot’s response, if Copilot displays a suggested prompt to provide recommendations to mitigate these impacts, then submit that prompt. If no such prompt appears, then manually enter this request in the prompt field and submit it.
+5. Ask Copilot to review these safety procedures and identify any areas that might be affected by the construction of the new warehouse wing and dock upgrades.
 
-7.  Review Copilot’s response. Also review the suggested prompts. Submit any of the prompts that interest you.
+6. Review Copilot's analysis and note the impacted areas. At the end of Copilot's response, if Copilot displays a suggested prompt to provide recommendations to mitigate these impacts, then submit that prompt. If no such prompt appears, then manually enter this request in the prompt field and submit it.
 
-8.  At this point, you want Copilot to update the safety protocols in lieu of the construction project. Ask Copilot to draft updated safety protocols that reflect temporary construction zones, new equipment, revised loading dock procedures, and emergency exit changes.
+7. Review Copilot's response. Also review the suggested prompts. Submit any of the prompts that interest you.
 
-9.  Review the draft that Copilot generated. Ask it to format this draft as a OneNote page with headings/icons.
+8. At this point, you want Copilot to update the safety protocols in light of the construction project. Ask Copilot to draft updated safety protocols that reflect temporary construction zones, new equipment, revised loading dock procedures, and emergency exit changes.
+
+9. Review the draft that Copilot generated. Ask it to format this draft as a OneNote page with headings and icons.
 
 10. Once Copilot completes this formatting, select the **Copy response** icon that appears at the end of the draft to copy the updated draft to your clipboard.
 
-11. Select **+Add page** in your current notebook in OneNote. Select in the title field on the page and enter **Expansion protocols** as the page title. Select into the page (below the title) and paste in the copied draft content **(Ctrl+V)**. Delete any extraneous conversational text that was copied in at the start and end of the content.
+11. Select **+ Add page** in your current notebook in OneNote. Select in the title field on the page and enter `Expansion protocols` as the page title. Select into the page (below the title) and paste in the copied draft content (**Ctrl+V**). Delete any extraneous conversational text that was copied in at the start and end of the content.
 
 12. To share these changes, ask Copilot to generate a concise summary of the safety protocol changes to share with Operations staff.
 
-13. Review the summary that Copilot generated. Feel free to request any changes. Once you’re satisfied with summary, select the **Copy response** icon that appears at the end of the draft to copy the summary to your clipboard.
+13. Review the summary that Copilot generated. Feel free to request any changes. Once you're satisfied with summary, select the **Copy response** icon that appears at the end of the draft to copy the summary to your clipboard.
 
-14. Add another page to your notebook and title it **Summary of protocol changes**. Paste in the copied content and delete any extraneous conversational text that was copied in at the start and end of the content.
+14. Add another page to your notebook and title it `Summary of protocol changes`. Paste in the copied content and delete any extraneous conversational text that was copied in at the start and end of the content.
 
-15. To facilitate sending this Summary page to the Operations staff in the next task, you want to save it as a PDF file. In OneNote, make sure the Summary page is still displayed. Then go to **File → Print**. On the **Print** page, select the **Print** icon to print this page. In the **Print** window, expand the **Printer** field, scroll to the top of the printer options and select **Save as PDF**. Select the **Save** button and save the PDF file to your OneDrive.
+15. To facilitate sending this Summary page to the Operations staff in the next task, you want to save it as a PDF file. In OneNote, make sure the Summary page is still displayed. Then go to **File** > **Print**. On the **Print** page, select the **Print** icon to print this page. In the **Print** window, expand the **Printer** drop-down, scroll to the top of the printer options and select **Save as PDF**. Select the **Save** button and save the PDF file to your OneDrive.
 
 

--- a/Instructions/Labs/M07-empower-workforce-copilot-operations/11-Ex2-4-use-onenote-update-safety-protocols.md
+++ b/Instructions/Labs/M07-empower-workforce-copilot-operations/11-Ex2-4-use-onenote-update-safety-protocols.md
@@ -17,10 +17,7 @@ Perform the following steps to complete this task:
 
 1. Select the following link to download the [**Contoso Expansion Safety Procedures.onepkg**](https://go.microsoft.com/fwlink/?linkid=2347515) file. Store the file in your OneDrive account for use by Copilot in your tenant.
 
-2. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page, select **Apps** in the navigation pane, and then on the **Apps** page, select **OneNote**.
-
-   > [!NOTE]
-   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **OneNote** from the list of apps that appears.
+2. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page, select the **App Launcher** (grid icon), and then select **More Apps**. From the list of apps, select **OneNote**.
 
 3. In **OneNote for the web**, in the list of OneNote files, the **Recent** list should display the **Safety Procedures** file. If the file doesn't appear in the list, enter `Contoso` in the **Search** box. The **Safety Procedures** file should appear in the list of files. Select the file to open it.
 

--- a/Instructions/Labs/M07-empower-workforce-copilot-operations/12-Ex2-5-use-outlook-email-safety-changes.md
+++ b/Instructions/Labs/M07-empower-workforce-copilot-operations/12-Ex2-5-use-outlook-email-safety-changes.md
@@ -9,58 +9,64 @@ lab:
 
 # Exercise 2, Task 5: Use Copilot in Outlook to email the safety procedure changes to Operations staff
 ---
-With the updated safety procedures summarized in OneNote and saved to a PDF file, it’s time to distribute the information to the Operations staff across the Fargo distribution center. Leadership wants staff to understand the changes before the next shift rotation, ensuring everyone is aware of new risks, restricted areas, and emergency updates. You plan to use Copilot in Outlook to draft a clear, informative communication and share the summary with the Operations team.
+With the updated safety procedures summarized in OneNote and saved to a PDF file, it's time to distribute the information to the Operations staff across the Fargo distribution center. Leadership wants staff to understand the changes before the next shift rotation, ensuring everyone is aware of new risks, restricted areas, and emergency updates. You plan to use Copilot in Outlook to draft a clear, informative communication and share the summary with the Operations team.
 
 Perform the following steps to complete this task:
 
-1.  In your Microsoft Edge browser, go to the **Microsoft 365** home page, select **Apps** in the navigation pane, and then select **Outlook** from the **Apps** menu.
+1. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page, select **Apps** in the navigation pane, and then select **Outlook** from the **Apps** menu.
 
-2.  In **Outlook on the web**, create a new email. Attach the PDF file of the Summary report that you saved to your OneDrive at the end of the prior task.
+   > [!NOTE]
+   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Outlook** from the list of apps that appears.
 
-3.  In the body of the message, select the **Open Copilot** (pencil) icon that appears next to the attached file.
+2. In **Outlook on the web**, create a new email. Attach the PDF file of the Summary report that you saved to your OneDrive at the end of the prior task.
 
-4.  The Copilot window that appears contains a prompt field and a menu of edit options below it. In the prompt field, ask Copilot to create an email to Contoso’s Operations staff at its Fargo distribution center. Ask Copilot to:
+3. In the body of the message, select the **Open Copilot** (pencil) icon that appears next to the attached file.
 
-    - Summarize the updates to the distribution center’s safety protocols that are found in the attached PDF file.
+4. The Copilot window that appears contains a prompt field and a menu of edit options below it. In the prompt field, ask Copilot to create an email to Contoso's Operations staff at its Fargo distribution center. Ask Copilot to:
+
+    - Summarize the updates to the distribution center's safety protocols that are found in the attached PDF file.
 
     - Include specific data points from the report into the email. At a minimum, identify new risks and restricted areas.
 
     - Highlight key insights, but keep the message concise and actionable.
 
-5.  Review the results. While it’s a good start, you feel that some things are missing. Ask Copilot to include information on emergency updates.
+5. Review the results. While it's a good start, you feel that some things are missing. Ask Copilot to include information on emergency updates.
 
-6.  Review the updated email. Notice how Copilot generated a new version of the email, which is draft 2 (2 of 2). You can select the back arrow to go to draft 1 of 2, which was the original version of the email that Copilot generated. Since you prefer to keep working with the latest draft, select the forward arrow to return to draft 2 of 2.
+6. Review the updated email. Notice how Copilot generated a new version of the email, which is draft 2 (2 of 2). You can select the back arrow to go to draft 1 of 2, which was the original version of the email that Copilot generated. Since you prefer to keep working with the latest draft, select the forward arrow to return to draft 2 of 2.
 
    > [!NOTE]
    > For each request that you make, Copilot generates a new draft of the email. You can optionally navigate to a prior draft and keep it, or you can ask Copilot to modify that draft (rather than the last draft). By default, you typically make each new request while viewing the last draft.
 
-7.  Review the results. You’re satisfied with this final update, so you’re ready to insert the draft into the actual email. In the Copilot menu, select the **Keep it** option to replace the original email with this final draft.
+7. Review the results. You're satisfied with this final update, so you're ready to insert the draft into the actual email. In the Copilot menu, select the **Replace** option to replace the original email with this final draft.
 
    > [!TIP]
-   > If you preferred one of the earlier drafts, you could select the forward or backward arrows to go to the preferred draft. Ensure the draft you want to use is displayed when you select the **Keep it** option.
+   > If you preferred one of the earlier drafts, you could select the forward or backward arrows to go to the preferred draft. Ensure the draft you want to use is displayed when you select the **Replace** option.
 
-8.  Review the results. Copilot should have inserted the draft into the actual body of the email. Now, once you use Copilot to draft the initial email, you can still use it to modify the email even after inserting the draft.
+8. Review the results. Copilot should have inserted the draft into the actual body of the email. Now, once you use Copilot to draft the initial email, you can still use it to modify the email even after inserting the draft.
 
     - When modifying an actual email message, you must highlight the portion of the email that you want changed, whether it be a sentence, paragraph, or the entire email.
 
     - Or if you want Copilot to add more text to the email, you must position the cursor where you want Copilot to insert the text.
 
-    While looking at the email, you decide to make one more change. You’re not sure about the tone of the email, so drag your cursor over the entire email to highlight all of its content. When you do so, note how Copilot displays the **Open Copilot** (pencil) icon.
+    While looking at the email, you decide to make one more change. You're not sure about the tone of the email, so drag your cursor over the entire email to highlight all of its content. When you do so, note how Copilot displays the **Open Copilot** (pencil) icon.
 
-9.  In the Copilot menu, select **Change Tone**, and then select one of the tone options.
+9. In the Copilot menu, select **Change Tone**, and then select one of the tone options.
 
-10.  Review the results of the modified email that appears in the draft window. You still aren’t satisfied with the way it sounds, so try a different tone.
+10. Review the results of the modified email that appears in the draft window. You still aren't satisfied with the way it sounds, so try a different tone.
 
-11.  Note how Copilot creates a second draft using the new tone. You’re satisfied with this version of the email, so select the **Replace** option to replace the current version of the email with this draft version.
+11. Note how Copilot creates a second draft using the new tone. You're satisfied with this version of the email, so select the **Replace** option to replace the current version of the email with this draft version.
 
-12.  After proofing the email one last time, you aren’t sure whether the paragraph on emergency updates should be longer. You decide to have Copilot draft a longer version of this paragraph to see how it sounds. To do so, highlight just that paragraph and then select the **Open Copilot** icon.
+12. After proofing the email one last time, you aren't sure whether the paragraph on emergency updates should be longer. You decide to have Copilot draft a longer version of this paragraph to see how it sounds. To do so, highlight just that paragraph and then select the **Open Copilot** icon.
 
-13.  In the Copilot menu that appears, select the **Make it longer** option. Copilot opens a draft window and creates an expanded version of that paragraph. After reading this updated version, you feel that the original version sounds better for your audience. You don’t want to implement this expanded version, so select the **Discard** option in the Copilot menu.
+13. In the Copilot menu that appears, select the **Make it longer** option. Copilot opens a draft window and creates an expanded version of that paragraph. After reading this updated version, you feel that the original version sounds better for your audience. You don't want to implement this expanded version, so select the **Discard** option in the Copilot menu.
 
-14.  Notice how Copilot returns you to the email with the original version of the emergency updates paragraph left intact.
+14. Notice how Copilot returns you to the email with the original version of the emergency updates paragraph left intact.
 
-15.  At this point, you’re happy with the email. For lab purposes, send the email to your personal email address. Verify that you received the email and were able to open the report.
+15. At this point, you're happy with the email. For lab purposes, send the email to your personal email address. Verify that you received the email and were able to open the report.
 
-At the end of this task, you should receive a professional, data-driven email that provides Contoso’s Operations staff with visibility into the safety protocol changes being implemented as part of the expansion project to the Fargo distribution center.
+> [!NOTE]
+> When you use Copilot to draft or modify an email, it may remove any previously attached files from the email body. Always verify that your attachments are still present before sending.
+
+At the end of this task, you should receive a professional, data-driven email that provides Contoso's Operations staff with visibility into the safety protocol changes being implemented as part of the expansion project to the Fargo distribution center.
 
 

--- a/Instructions/Labs/M07-empower-workforce-copilot-operations/12-Ex2-5-use-outlook-email-safety-changes.md
+++ b/Instructions/Labs/M07-empower-workforce-copilot-operations/12-Ex2-5-use-outlook-email-safety-changes.md
@@ -13,10 +13,7 @@ With the updated safety procedures summarized in OneNote and saved to a PDF file
 
 Perform the following steps to complete this task:
 
-1. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page, select **Apps** in the navigation pane, and then select **Outlook** from the **Apps** menu.
-
-   > [!NOTE]
-   > If **Apps** does not appear in the navigation pane, you can select the **App Launcher** icon (grid icon) in the top left corner of the page, select **More Apps**, and then select **Outlook** from the list of apps that appears.
+1. In your Microsoft Edge browser, go to the **Microsoft 365 Copilot** home page, select the **App Launcher** (grid icon), and then select **More Apps**. From the list of apps, select **Outlook**.
 
 2. In **Outlook on the web**, create a new email. Attach the PDF file of the Summary report that you saved to your OneDrive at the end of the prior task.
 


### PR DESCRIPTION
## Summary

This PR revises the entire **M07 — Empower your workforce with Copilot (Operations)** lab module to align with Microsoft Learn style guidelines and to correct UI drift across the Microsoft 365 Copilot experience. It applies consistent typography, fixes outdated UI references (navigation paths, button labels, Copilot Studio Agent Builder), and adds clarifying notes so learners can complete each task against the current product UI.

## Changes

### Exercise 1
- **Lab intro & Exercise 1 intro** — Applied Microsoft Learn typography and style conventions; replaced curly/smart quotes with straight quotes.
- **Task 1 (Whiteboard)** — Replaced `<br/>` HTML tags with proper Markdown list continuation.
- **Task 2 (Word — compare reports)** — Updated Copilot edit/chat mode steps to match current UI drift.
- **Task 3 (PowerPoint)** — Corrected Copilot UI paths and added confirmation notes for clarity.
- **Task 4 (Chat — vendor engagement)** — Corrected Copilot chat steps and removed invalid suggested prompts.

### Exercise 2
- **Exercise 2 intro** — Fixed smart quotes.
- **Task 1 (Loop — track milestones)** — Updated Loop UI steps, corrected the Microsoft 365 URL to **Microsoft 365 Copilot**, fixed grammar ("delete any extraneous text", "Operations Lead"), and applied style fixes.
- **Task 2 (Copilot Studio — Facility Expansion FAQ agent)** — Updated for Copilot Studio Agent Builder UI drift: revised navigation (**Agents** > **Create agent**), replaced the **Describe**/**Configure** tabs with the current **Agent Builder** chat pane plus **Configure**/**Preview** tabs, updated the **Web search** toggle label, the **+ Add knowledge** flow, and the **+ Add a suggested prompt** control; cleaned up the lab metadata description and fixed straight-quote/hyphen typography.
- **Task 3 (use the agent)** — Fixed typography, removed a duplicated sentence in step 3, and corrected grammar.
- **Task 4 (OneNote — update safety protocols)** — Corrected OneNote UI references (**Recent** list, **Microsoft 365 Copilot** home, **+ Add page**, **File** > **Print**, **Printer** drop-down), added an **Apps**/App Launcher fallback note, fixed "in light of", and applied style fixes.
- **Task 5 (Outlook — email safety changes)** — Corrected Outlook Copilot UI references (**Microsoft 365 Copilot** home, **Replace** button replacing **Keep it**), renumbered steps, added an **Apps**/App Launcher fallback note and a note about Copilot removing attachments, and applied style fixes.

## Files changed

- `Instructions/Labs/M07-empower-workforce-copilot-operations/01-introduction.md` — Applied Microsoft Learn style and typography to the lab introduction.
- `Instructions/Labs/M07-empower-workforce-copilot-operations/02-Ex1-introduction-streamline-initiatives-exercise.md` — Applied Microsoft Learn typography to the Exercise 1 introduction.
- `Instructions/Labs/M07-empower-workforce-copilot-operations/03-Ex1-1-use-whiteboard-brainstorm-ideas.md` — Replaced `<br/>` tags with Markdown list continuation.
- `Instructions/Labs/M07-empower-workforce-copilot-operations/04-Ex1-2-use-word-compare-reports.md` — Updated Word Copilot edit/chat mode steps for UI drift.
- `Instructions/Labs/M07-empower-workforce-copilot-operations/05-Ex1-3-use-powerpoint-create-presentation.md` — Updated PowerPoint Copilot UI paths and added confirmation notes.
- `Instructions/Labs/M07-empower-workforce-copilot-operations/06-Ex1-4-use-chat-prepare-vendor-engagement.md` — Corrected Copilot chat steps and removed invalid suggested prompts.
- `Instructions/Labs/M07-empower-workforce-copilot-operations/07-Ex2-introduction-manage-expansion-exercise.md` — Fixed smart quotes.
- `Instructions/Labs/M07-empower-workforce-copilot-operations/08-Ex2-1-use-loop-track-milestones.md` — Updated Loop UI steps, M365 Copilot URL, grammar, and style fixes.
- `Instructions/Labs/M07-empower-workforce-copilot-operations/09-Ex2-2-create-facility-expansion-agent.md` — Updated Copilot Studio Agent Builder steps for UI drift and applied style fixes.
- `Instructions/Labs/M07-empower-workforce-copilot-operations/10-Ex2-3-use-facility-expansion-agent.md` — Removed duplicate sentence, fixed grammar and typography.
- `Instructions/Labs/M07-empower-workforce-copilot-operations/11-Ex2-4-use-onenote-update-safety-protocols.md` — Corrected OneNote UI references and applied style fixes.
- `Instructions/Labs/M07-empower-workforce-copilot-operations/12-Ex2-5-use-outlook-email-safety-changes.md` — Corrected Outlook Copilot UI references and applied style fixes.
